### PR TITLE
feat(nav): add Admin link for logged-in users

### DIFF
--- a/packages/blog/app/components/AppHeader.vue
+++ b/packages/blog/app/components/AppHeader.vue
@@ -31,7 +31,15 @@ const items = computed(() => [
     'icon': 'i-heroicons-chat-bubble-left-right',
     'active': route.path.startsWith('/chat'),
     'data-testid': TEST_IDS.NAVIGATION.CHAT_LINK
-  }])
+  },
+  ...(loggedIn.value
+    ? [{
+        label: 'Admin',
+        to: '/admin',
+        icon: 'i-heroicons-cog-6-tooth',
+        active: route.path.startsWith('/admin')
+      }]
+    : [])])
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- Adds conditional "Admin" nav item in AppHeader that only appears when user is logged in
- Links to `/admin` with cog icon

## Test plan
- [x] Verify Admin link hidden when logged out
- [x] Verify Admin link appears after login
- [x] Verify link navigates to /admin