### PR TITLE
Add code execution, skills, and file generation to chat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ pnpm gcp:staging:deploy # Build container + deploy to GCP staging
 
 The blog includes several AI-powered features built on the Anthropic SDK:
 
-- **Chat** (`/chat`) — Conversational AI with tool use (search blog, weather, dice). Server-streamed via SSE. See `server/api/chats/`.
+- **Chat** (`/chat`) — Conversational AI with tool use (search blog, weather, dice), code execution, and document generation (PDF/PPTX/XLSX/DOCX via Skills API). Server-streamed via SSE. See `server/api/chats/`.
 - **Artifacts** — Interactive code execution embedded in blog posts via `::code-runner` MDC component. Uses Anthropic's Code Execution Tool (beta) to run code in isolated containers. See `server/api/artifacts/` and `app/components/CodeRunner.vue`.
 - **RAG** — Blog content is chunked and embedded for semantic search. See `server/utils/rag/`.
 

--- a/packages/blog/CLAUDE.md
+++ b/packages/blog/CLAUDE.md
@@ -187,3 +187,4 @@ Test files live next to source: `foo.ts` → `foo.test.ts`
 - **Syntax highlighting** — use `useHighlighter()` composable with `material-theme-palenight` theme (Shiki).
 - **Model config** — use `useRuntimeConfig().public.model` instead of hardcoding model strings.
 - **Debugging beta APIs** — beta client methods cast via `AnthropicBetaClient` can silently fail in try/catch. Check `tail /tmp/nuxt-dev.log | grep -i warn` for swallowed errors.
+- **Dev server startup** — always use `pnpm dev` from repo root (runs `docker:up`, `db:migrate`, `kill-port`). Using `pnpm --filter @chris-towles/blog dev` skips those steps and can leave stale servers on other ports.

--- a/packages/blog/app/components/ChatCodeExecution.vue
+++ b/packages/blog/app/components/ChatCodeExecution.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import type { CodeExecutionPart } from '~~/shared/chat-types';
+
+defineProps<{
+  execution: CodeExecutionPart;
+}>();
+
+const showCode = ref(false);
+</script>
+
+<template>
+  <div class="my-2 space-y-2">
+    <!-- Running indicator -->
+    <div v-if="execution.state === 'running'" class="flex items-center gap-2 text-sm text-muted">
+      <UIcon name="i-lucide-loader-2" class="size-4 animate-spin" />
+      <span>Running code...</span>
+    </div>
+
+    <!-- Executed code (collapsible) -->
+    <div v-if="execution.code">
+      <button
+        class="flex items-center gap-1.5 text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+        @click="showCode = !showCode"
+      >
+        <UIcon
+          :name="showCode ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'"
+          class="size-3.5"
+        />
+        <UIcon name="i-lucide-code-2" class="size-3.5" />
+        <span>{{ execution.language }} code executed</span>
+      </button>
+      <div v-if="showCode" class="mt-2">
+        <pre
+          class="rounded-md bg-zinc-900 border border-zinc-800 p-3 text-xs overflow-x-auto"
+        ><code>{{ execution.code }}</code></pre>
+      </div>
+    </div>
+
+    <!-- stdout -->
+    <div
+      v-if="execution.stdout && execution.state === 'done'"
+      class="rounded-md bg-zinc-900 border border-zinc-800 p-3 text-xs font-mono overflow-x-auto"
+    >
+      <div
+        class="flex items-center gap-1.5 text-zinc-500 mb-2 text-[10px] uppercase tracking-wider"
+      >
+        <UIcon name="i-lucide-terminal" class="size-3" />
+        Output
+      </div>
+      <pre class="text-zinc-200 whitespace-pre-wrap">{{ execution.stdout }}</pre>
+    </div>
+
+    <!-- stderr -->
+    <div
+      v-if="execution.stderr && execution.state === 'done'"
+      class="rounded-md bg-red-950/30 border border-red-900/30 p-3 text-xs font-mono overflow-x-auto"
+    >
+      <div class="flex items-center gap-1.5 text-red-400 mb-2 text-[10px] uppercase tracking-wider">
+        <UIcon name="i-lucide-alert-triangle" class="size-3" />
+        Stderr
+      </div>
+      <pre class="text-red-300 whitespace-pre-wrap">{{ execution.stderr }}</pre>
+    </div>
+  </div>
+</template>

--- a/packages/blog/app/components/ChatFile.vue
+++ b/packages/blog/app/components/ChatFile.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import type { FilePart } from '~~/shared/chat-types';
+
+const props = defineProps<{
+  file: FilePart;
+}>();
+
+function isImage(): boolean {
+  return props.file.mediaType.startsWith('image/');
+}
+
+const fileTypeIcons: Record<string, string> = {
+  'application/pdf': 'i-lucide-file-text',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation':
+    'i-lucide-presentation',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'i-lucide-sheet',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'i-lucide-file-text',
+};
+
+function getIcon(): string {
+  return fileTypeIcons[props.file.mediaType] || 'i-lucide-file';
+}
+</script>
+
+<template>
+  <div class="my-2">
+    <!-- Image preview -->
+    <div v-if="isImage()" class="rounded-md overflow-hidden border border-zinc-700">
+      <img :src="file.url" :alt="file.fileName" class="w-full" loading="lazy" />
+      <div class="flex items-center justify-between px-3 py-1.5 bg-zinc-900 text-xs text-zinc-500">
+        <span>{{ file.fileName }}</span>
+        <a :href="file.url" download class="hover:text-zinc-300 transition-colors">
+          <UIcon name="i-lucide-download" class="size-3.5" />
+        </a>
+      </div>
+    </div>
+
+    <!-- Document download -->
+    <div v-else class="flex items-center gap-3 rounded-md border border-zinc-700 bg-zinc-900 p-3">
+      <UIcon :name="getIcon()" class="size-5 text-sky-400 shrink-0" />
+      <div class="flex-1 min-w-0">
+        <div class="text-sm text-zinc-200 truncate">{{ file.fileName }}</div>
+        <div class="text-xs text-zinc-500">{{ file.mediaType }}</div>
+      </div>
+      <a :href="file.url" download class="text-sky-400 hover:text-sky-300 transition-colors">
+        <UIcon name="i-lucide-download" class="size-4" />
+      </a>
+    </div>
+  </div>
+</template>

--- a/packages/blog/app/composables/useChat.ts
+++ b/packages/blog/app/composables/useChat.ts
@@ -1,6 +1,8 @@
 import type {
   ChatMessage,
   ChatStatus,
+  CodeExecutionPart,
+  FilePart,
   MessagePart,
   SSEEvent,
   ToolUsePart,
@@ -21,6 +23,16 @@ interface ToolInvocation {
   args: Record<string, unknown>;
   state: 'pending' | 'complete';
   result?: unknown;
+}
+
+interface CodeExecution {
+  code: string;
+  language: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  state: 'running' | 'done';
+  files: FilePart[];
 }
 
 export function useChat(options: UseChatOptions) {
@@ -82,6 +94,7 @@ export function useChat(options: UseChatOptions) {
         state: 'streaming' | 'done';
       } | null = null;
       const toolInvocations: ToolInvocation[] = [];
+      const codeExecutions: CodeExecution[] = [];
 
       while (true) {
         const { done, value } = await reader.read();
@@ -109,6 +122,7 @@ export function useChat(options: UseChatOptions) {
                   currentReasoningPart,
                   currentTextPart,
                   toolInvocations,
+                  codeExecutions,
                 );
               } else if (event.type === 'reasoning') {
                 if (!currentReasoningPart) {
@@ -122,6 +136,7 @@ export function useChat(options: UseChatOptions) {
                   currentReasoningPart,
                   currentTextPart,
                   toolInvocations,
+                  codeExecutions,
                 );
               } else if (event.type === 'tool_start') {
                 toolInvocations.push({
@@ -135,6 +150,7 @@ export function useChat(options: UseChatOptions) {
                   currentReasoningPart,
                   currentTextPart,
                   toolInvocations,
+                  codeExecutions,
                 );
               } else if (event.type === 'tool_end') {
                 const invocation = toolInvocations.find((t) => t.toolCallId === event.toolCallId);
@@ -147,7 +163,43 @@ export function useChat(options: UseChatOptions) {
                   currentReasoningPart,
                   currentTextPart,
                   toolInvocations,
+                  codeExecutions,
                 );
+              } else if (event.type === 'code_start') {
+                codeExecutions.push({
+                  code: event.code,
+                  language: event.language,
+                  stdout: '',
+                  stderr: '',
+                  exitCode: 0,
+                  state: 'running',
+                  files: [],
+                });
+                updateAssistantMessage(
+                  assistantMessageId,
+                  currentReasoningPart,
+                  currentTextPart,
+                  toolInvocations,
+                  codeExecutions,
+                );
+              } else if (event.type === 'code_result') {
+                const lastExecution = codeExecutions[codeExecutions.length - 1];
+                if (lastExecution) {
+                  lastExecution.stdout = event.stdout;
+                  lastExecution.stderr = event.stderr;
+                  lastExecution.exitCode = event.exitCode;
+                  lastExecution.state = 'done';
+                  lastExecution.files = event.files;
+                }
+                updateAssistantMessage(
+                  assistantMessageId,
+                  currentReasoningPart,
+                  currentTextPart,
+                  toolInvocations,
+                  codeExecutions,
+                );
+              } else if (event.type === 'container') {
+                // Container ID received — stored server-side, no client action needed
               } else if (event.type === 'title') {
                 options.onTitleUpdate?.();
               } else if (event.type === 'done') {
@@ -159,6 +211,7 @@ export function useChat(options: UseChatOptions) {
                   currentReasoningPart,
                   currentTextPart,
                   toolInvocations,
+                  codeExecutions,
                 );
               } else if (event.type === 'error') {
                 throw new Error(event.error);
@@ -190,6 +243,7 @@ export function useChat(options: UseChatOptions) {
     reasoning: { type: 'reasoning'; text: string; state: 'streaming' | 'done' } | null,
     text: { type: 'text'; text: string } | null,
     tools: ToolInvocation[] = [],
+    executions: CodeExecution[] = [],
   ) {
     const parts: MessagePart[] = [];
     if (reasoning) parts.push(reasoning);
@@ -211,6 +265,25 @@ export function useChat(options: UseChatOptions) {
           result: tool.result,
         };
         parts.push(toolResultPart);
+      }
+    }
+
+    // Add code execution parts
+    for (const exec of executions) {
+      const cePart: CodeExecutionPart = {
+        type: 'code-execution',
+        code: exec.code,
+        language: exec.language,
+        stdout: exec.stdout,
+        stderr: exec.stderr,
+        exitCode: exec.exitCode,
+        state: exec.state,
+      };
+      parts.push(cePart);
+
+      // Add file parts from this execution
+      for (const file of exec.files) {
+        parts.push(file);
       }
     }
 

--- a/packages/blog/app/pages/chat/[id].vue
+++ b/packages/blog/app/pages/chat/[id].vue
@@ -1,7 +1,13 @@
 <script setup lang="ts">
 import type { DefineComponent } from 'vue';
 import { useClipboard } from '@vueuse/core';
-import type { ChatMessage, ToolUsePart, ToolResultPart } from '~~/shared/chat-types';
+import type {
+  ChatMessage,
+  CodeExecutionPart,
+  FilePart,
+  ToolUsePart,
+  ToolResultPart,
+} from '~~/shared/chat-types';
 import ProsePre from '../../components/prose/ProsePre.vue';
 
 definePageMeta({
@@ -155,6 +161,11 @@ onMounted(() => {
                   :tool-use="part"
                   :tool-result="getToolResult(message, part)"
                 />
+                <ChatCodeExecution
+                  v-else-if="part.type === 'code-execution'"
+                  :execution="part as CodeExecutionPart"
+                />
+                <ChatFile v-else-if="part.type === 'file'" :file="part as FilePart" />
                 <MDCCached
                   v-else-if="part.type === 'text'"
                   :value="part.text"

--- a/packages/blog/server/CLAUDE.md
+++ b/packages/blog/server/CLAUDE.md
@@ -52,6 +52,7 @@ Both chat and artifacts use Anthropic beta APIs. Chat uses `beta.messages.stream
 - `tool_use` blocks are client-side (our tools like weather, dice) — execute locally and loop
 - `bash_code_execution_tool_result` / `text_editor_code_execution_tool_result` content blocks for stdout/stderr
 - Code execution results (`*_tool_result` blocks) are processed inline during streaming via `content_block_start` for fast UI updates
+- `content_block_start` for `*_tool_result` blocks contains full result in `content_block.content` (stdout, stderr, return_code, content[].file_id) — no deltas needed
 - Files referenced by `file_id`, downloaded via Files API beta — metadata via `client.beta.files.retrieveMetadata()` (NOT `retrieve`)
 - Container ID persisted in `chats.containerId` for reuse across turns
 - Skills loaded from `.claude/skills/*/SKILL.md` via `utils/ai/skills-loader.ts` (cached at startup)
@@ -69,6 +70,16 @@ PostgreSQL with Drizzle ORM.
 - **Migrations**: `pnpm db:generate` → `pnpm db:migrate`
 
 UUID primary keys generated via `crypto.randomUUID()`. All tables have `createdAt` timestamp.
+
+### Custom SQL Migrations
+
+Drizzle can't express `tsvector` columns, triggers, or GIN indexes. For these:
+1. Create SQL file manually in `database/migrations/` (e.g. `0002_fix_name.sql`)
+2. Add entry to `meta/_journal.json` with next `idx`
+3. Copy previous snapshot as new `meta/NNNN_snapshot.json` (update `id`/`prevId` UUIDs)
+4. Keep Drizzle schema using `text().$type<string>()` workaround — don't change it
+
+The `document_chunks.searchVector` column is `text()` in Drizzle but `tsvector` in PostgreSQL (via custom migration). A trigger auto-populates it from `content` + `contextualContent`.
 
 ## RAG (Retrieval-Augmented Generation)
 

--- a/packages/blog/server/CLAUDE.md
+++ b/packages/blog/server/CLAUDE.md
@@ -42,13 +42,20 @@ Event types are defined in `shared/chat-types.ts` and `shared/artifact-types.ts`
 - **Tools**: Defined in `utils/ai/tools.ts` (Anthropic SDK format) and `utils/ai/tools/*.ts` (Agent SDK format)
 - **Thread safety**: Tool execution must be stateless. No module-level mutable state — pass context as parameters.
 
-### Artifact Execution
+### Beta Streaming (Chat + Artifacts)
 
-Uses Anthropic beta APIs — the beta headers and response shapes may change:
+Both chat and artifacts use Anthropic beta APIs. Chat uses `beta.messages.stream()` (not `client.messages.stream()`) for streaming with code execution.
 
+- Beta headers: `code-execution-2025-08-25`, `files-api-2025-04-14`, `skills-2025-10-02`
 - `code_execution_20250825` tool type for sandboxed execution
+- `server_tool_use` blocks are server-side (code execution) — do NOT add to client tool loop
+- `tool_use` blocks are client-side (our tools like weather, dice) — execute locally and loop
 - `bash_code_execution_tool_result` / `text_editor_code_execution_tool_result` content blocks for stdout/stderr
+- Code execution results (`*_tool_result` blocks) are processed inline during streaming via `content_block_start` for fast UI updates
 - Files referenced by `file_id`, downloaded via Files API beta — metadata via `client.beta.files.retrieveMetadata()` (NOT `retrieve`)
+- Container ID persisted in `chats.containerId` for reuse across turns
+- Skills loaded from `.claude/skills/*/SKILL.md` via `utils/ai/skills-loader.ts` (cached at startup)
+- Pre-built Anthropic skills: `pdf`, `pptx`, `xlsx`, `docx` (NOT `create-pdf` — see https://platform.claude.com/docs/en/build-with-claude/skills-guide)
 - Beta response types are unstable — typed interfaces in `utils/ai/anthropic-beta-types.ts` use `any` for `content` fields where union narrowing is impractical
 - Hoist `TextEncoder` to module scope (not per-function call) in SSE streaming handlers
 
@@ -58,7 +65,7 @@ PostgreSQL with Drizzle ORM.
 
 - **Schema**: `database/schema.ts`
 - **Access**: `useDrizzle()` from `utils/drizzle.ts` (creates connection per call)
-- **Tables**: `tables.chats`, `tables.messages`, `tables.users`, `tables.documents`, `tables.documentChunks`
+- **Tables**: `tables.chats` (with `containerId` for container reuse), `tables.messages`, `tables.users`, `tables.documents`, `tables.documentChunks`
 - **Migrations**: `pnpm db:generate` → `pnpm db:migrate`
 
 UUID primary keys generated via `crypto.randomUUID()`. All tables have `createdAt` timestamp.

--- a/packages/blog/server/CLAUDE.md
+++ b/packages/blog/server/CLAUDE.md
@@ -74,6 +74,7 @@ UUID primary keys generated via `crypto.randomUUID()`. All tables have `createdA
 ### Custom SQL Migrations
 
 Drizzle can't express `tsvector` columns, triggers, or GIN indexes. For these:
+
 1. Create SQL file manually in `database/migrations/` (e.g. `0002_fix_name.sql`)
 2. Add entry to `meta/_journal.json` with next `idx`
 3. Copy previous snapshot as new `meta/NNNN_snapshot.json` (update `id`/`prevId` UUIDs)

--- a/packages/blog/server/api/chats/[id].post.ts
+++ b/packages/blog/server/api/chats/[id].post.ts
@@ -1,6 +1,14 @@
 import type { MessageParam } from '@anthropic-ai/sdk/resources/messages';
 import { z } from 'zod';
-import type { ChatMessage, MessagePart, SSEEvent } from '~~/shared/chat-types';
+import type {
+  ChatMessage,
+  CodeExecutionPart,
+  FilePart,
+  MessagePart,
+  SSEEvent,
+} from '~~/shared/chat-types';
+import type { AnthropicBetaClient, BetaStreamEvent } from '~~/server/utils/ai/anthropic-beta-types';
+import { getSkillsForAPI, getSkillsSystemPrompt } from '~~/server/utils/ai/skills-loader';
 
 defineRouteMeta({
   openAPI: {
@@ -119,6 +127,11 @@ export default defineEventHandler(async (event) => {
   const requestUrl = getRequestURL(event);
   const baseUrl = `${requestUrl.protocol}//${requestUrl.host}`;
 
+  // Load skills config for container
+  const skills = getSkillsForAPI();
+  const skillsPrompt = getSkillsSystemPrompt();
+  const fullSystemPrompt = `${SYSTEM_PROMPT}\n\n${skillsPrompt}`;
+
   // Create SSE stream
   const stream = new ReadableStream({
     async start(controller) {
@@ -128,6 +141,7 @@ export default defineEventHandler(async (event) => {
         }
 
         const client = getAnthropicClient();
+        const betaClient = client as unknown as AnthropicBetaClient;
         const anthropicMessages = convertToAnthropicMessages(messages);
 
         let fullText = '';
@@ -136,21 +150,45 @@ export default defineEventHandler(async (event) => {
         let currentToolUseId: string | null = null;
         let currentToolName: string | null = null;
         let _toolInputJson = '';
+        // Track server-side tool use blocks (code execution)
+        let currentServerToolName: string | null = null;
+        let currentServerToolInput = '';
+        let isServerToolBlock = false;
+
+        // Track code executions and files for message persistence
+        const codeExecutions: CodeExecutionPart[] = [];
+        const fileParts: FilePart[] = [];
 
         // Run up to 5 turns for tool use
         let turnCount = 0;
         const maxTurns = 5;
         let currentMessages = [...anthropicMessages];
 
+        // Container config — reuse from previous turns in this chat
+        let containerId = chat.containerId || undefined;
+
         while (turnCount < maxTurns) {
           turnCount++;
 
-          const streamResponse = await client.messages.stream({
+          const streamResponse = betaClient.beta.messages.stream({
             model,
             max_tokens: 16000,
-            system: SYSTEM_PROMPT,
+            system: fullSystemPrompt,
             messages: currentMessages,
-            tools: chatTools,
+            betas: ['code-execution-2025-08-25', 'files-api-2025-04-14', 'skills-2025-10-02'],
+            tools: [
+              // Client-side tools (we execute these)
+              ...chatTools,
+              // Server-side code execution tool (Anthropic executes this)
+              {
+                type: 'code_execution_20250825',
+                name: 'code_execution',
+              },
+            ],
+            container: {
+              ...(containerId ? { id: containerId } : {}),
+              skills,
+            },
             thinking: {
               type: 'enabled',
               budget_tokens: 4096,
@@ -158,39 +196,99 @@ export default defineEventHandler(async (event) => {
           });
 
           let hasToolUse = false;
-          let turnThinking = ''; // Track thinking for this turn only
-          let turnThinkingSignature = ''; // Track signature for this turn's thinking
+          let turnThinking = '';
+          let turnThinkingSignature = '';
           const toolResults: { type: 'tool_result'; tool_use_id: string; content: string }[] = [];
           const toolUses: { id: string; name: string; input: Record<string, unknown> }[] = [];
 
-          for await (const event of streamResponse) {
-            if (event.type === 'content_block_start') {
-              if (event.content_block.type === 'thinking') {
+          for await (const streamEvent of streamResponse as AsyncIterable<BetaStreamEvent>) {
+            if (streamEvent.type === 'message_start') {
+              // Extract container ID from message_start for reuse
+              const msgContainerId = streamEvent.message?.container?.id;
+              if (msgContainerId && msgContainerId !== containerId) {
+                containerId = msgContainerId;
+                sendSSE(controller, { type: 'container', containerId: msgContainerId });
+              }
+            } else if (streamEvent.type === 'content_block_start') {
+              const block = streamEvent.content_block;
+
+              if (block.type === 'thinking') {
                 // Extended thinking block starting
-              } else if (event.content_block.type === 'tool_use') {
-                currentToolUseId = event.content_block.id;
-                currentToolName = event.content_block.name;
+              } else if (block.type === 'tool_use') {
+                // Client-side tool use (our custom tools)
+                currentToolUseId = block.id || null;
+                currentToolName = block.name || null;
                 _toolInputJson = '';
                 hasToolUse = true;
-                // Will send tool_start after we have full args
+                isServerToolBlock = false;
+              } else if (block.type === 'server_tool_use') {
+                // Server-side tool use (code execution — handled by Anthropic)
+                currentServerToolName = block.name || null;
+                currentServerToolInput = '';
+                isServerToolBlock = true;
               }
-            } else if (event.type === 'content_block_delta') {
-              if (event.delta.type === 'thinking_delta') {
-                reasoningText += event.delta.thinking;
-                turnThinking += event.delta.thinking;
-                sendSSE(controller, { type: 'reasoning', text: event.delta.thinking });
-              } else if (event.delta.type === 'signature_delta') {
-                // Capture signature for thinking block (required when passing back to API)
-                turnThinkingSignature += event.delta.signature;
-              } else if (event.delta.type === 'text_delta') {
-                fullText += event.delta.text;
-                sendSSE(controller, { type: 'text', text: event.delta.text });
-              } else if (event.delta.type === 'input_json_delta') {
-                _toolInputJson += event.delta.partial_json;
+            } else if (streamEvent.type === 'content_block_delta') {
+              const delta = streamEvent.delta;
+
+              if (delta.type === 'thinking_delta') {
+                reasoningText += delta.thinking;
+                turnThinking += delta.thinking;
+                sendSSE(controller, { type: 'reasoning', text: delta.thinking });
+              } else if (delta.type === 'signature_delta') {
+                turnThinkingSignature += delta.signature;
+              } else if (delta.type === 'text_delta') {
+                fullText += delta.text;
+                sendSSE(controller, { type: 'text', text: delta.text });
+              } else if (delta.type === 'input_json_delta') {
+                if (isServerToolBlock) {
+                  currentServerToolInput += delta.partial_json;
+                } else {
+                  _toolInputJson += delta.partial_json;
+                }
               }
-            } else if (event.type === 'content_block_stop') {
-              if (currentToolUseId && currentToolName) {
-                // Parse tool input and execute tool
+            } else if (streamEvent.type === 'content_block_stop') {
+              if (isServerToolBlock && currentServerToolName) {
+                // Server tool use block completed — send code_start SSE
+                let code = '';
+                let language = 'bash';
+                try {
+                  const input = currentServerToolInput ? JSON.parse(currentServerToolInput) : {};
+                  if (
+                    currentServerToolName === 'bash_code_execution' ||
+                    currentServerToolName === 'bash'
+                  ) {
+                    code = input.command || '';
+                    language = 'bash';
+                  } else if (
+                    currentServerToolName === 'text_editor_code_execution' ||
+                    currentServerToolName === 'text_editor'
+                  ) {
+                    code = input.file_text || '';
+                    language = (input.path as string)?.split('.').pop() || 'python';
+                  }
+                } catch {
+                  // Input parsing failed — still send what we have
+                }
+
+                if (code) {
+                  sendSSE(controller, { type: 'code_start', code, language });
+                  // Track for message persistence
+                  codeExecutions.push({
+                    type: 'code-execution',
+                    code,
+                    language,
+                    stdout: '',
+                    stderr: '',
+                    exitCode: 0,
+                    state: 'running',
+                  });
+                }
+
+                currentServerToolName = null;
+                currentServerToolInput = '';
+                isServerToolBlock = false;
+              } else if (currentToolUseId && currentToolName) {
+                // Client-side tool block completed — parse and execute
                 let toolArgs: Record<string, unknown> = {};
                 try {
                   if (_toolInputJson) {
@@ -214,14 +312,12 @@ export default defineEventHandler(async (event) => {
                   continue;
                 }
 
-                // Track the tool use for message history
                 toolUses.push({
                   id: currentToolUseId,
                   name: currentToolName,
                   input: toolArgs,
                 });
 
-                // Notify client tool is starting with full args
                 sendSSE(controller, {
                   type: 'tool_start',
                   tool: currentToolName,
@@ -229,7 +325,6 @@ export default defineEventHandler(async (event) => {
                   args: toolArgs,
                 });
 
-                // Execute the tool
                 const toolResult = await executeTool(currentToolName, toolArgs, { baseUrl });
                 toolResults.push({
                   type: 'tool_result',
@@ -237,7 +332,6 @@ export default defineEventHandler(async (event) => {
                   content: JSON.stringify(toolResult),
                 });
 
-                // Notify client of tool result
                 sendSSE(controller, {
                   type: 'tool_end',
                   tool: currentToolName,
@@ -252,15 +346,93 @@ export default defineEventHandler(async (event) => {
             }
           }
 
-          // If tool was used, continue the conversation
+          // After stream completes, process the final message for code execution results
+          try {
+            const finalMessage = await streamResponse.finalMessage();
+
+            // Extract container ID from final message too
+            if (finalMessage.container?.id && finalMessage.container.id !== containerId) {
+              containerId = finalMessage.container.id;
+              sendSSE(controller, { type: 'container', containerId: finalMessage.container.id });
+            }
+
+            // Process code execution result blocks from the final message
+            const seenFileIds = new Set<string>();
+
+            for (const block of finalMessage.content) {
+              if (
+                block.type === 'bash_code_execution_tool_result' ||
+                block.type === 'text_editor_code_execution_tool_result'
+              ) {
+                const result = block.content;
+                const stdout = result?.stdout || '';
+                const stderr = result?.stderr || '';
+                const exitCode = result?.return_code ?? 0;
+
+                // Collect files from this result block
+                const resultFiles: FilePart[] = [];
+                if (Array.isArray(result?.content)) {
+                  for (const item of result.content) {
+                    if (item.file_id && !seenFileIds.has(item.file_id)) {
+                      seenFileIds.add(item.file_id);
+                      let fileName = 'output';
+                      let mediaType = 'application/octet-stream';
+                      try {
+                        const meta = await betaClient.beta.files.retrieveMetadata(item.file_id, {
+                          betas: ['files-api-2025-04-14'],
+                        });
+                        fileName = meta.filename || fileName;
+                        mediaType = meta.mime_type || mediaType;
+                      } catch (e) {
+                        console.warn(
+                          `[chat] Failed to fetch file metadata for ${item.file_id}:`,
+                          e,
+                        );
+                      }
+
+                      const filePart: FilePart = {
+                        type: 'file',
+                        fileId: item.file_id,
+                        fileName,
+                        mediaType,
+                        url: `/api/artifacts/files/${item.file_id}`,
+                      };
+                      resultFiles.push(filePart);
+                      fileParts.push(filePart);
+                    }
+                  }
+                }
+
+                // Update the last running code execution with results
+                const lastRunning = codeExecutions.findLast((ce) => ce.state === 'running');
+                if (lastRunning) {
+                  lastRunning.stdout = stdout;
+                  lastRunning.stderr = stderr;
+                  lastRunning.exitCode = exitCode;
+                  lastRunning.state = 'done';
+                }
+
+                sendSSE(controller, {
+                  type: 'code_result',
+                  stdout,
+                  stderr,
+                  exitCode,
+                  files: resultFiles,
+                });
+              }
+            }
+          } catch (e) {
+            // finalMessage() may fail if the stream was incomplete — log and continue
+            console.warn('[chat] Failed to process final message:', e);
+          }
+
+          // If client-side tool was used, continue the conversation
           if (hasToolUse && toolResults.length > 0) {
-            // Add assistant's response to messages - must include thinking block with signature when extended thinking is enabled
             const assistantContent: Array<
               | { type: 'thinking'; thinking: string; signature: string }
               | { type: 'text'; text: string }
               | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
             > = [];
-            // Thinking must come first in the content array (with signature for API verification)
             if (turnThinking && turnThinkingSignature) {
               assistantContent.push({
                 type: 'thinking',
@@ -271,7 +443,6 @@ export default defineEventHandler(async (event) => {
             if (fullText) {
               assistantContent.push({ type: 'text', text: fullText });
             }
-            // Add actual tool uses with correct names and inputs
             for (const toolUse of toolUses) {
               assistantContent.push({
                 type: 'tool_use',
@@ -296,15 +467,28 @@ export default defineEventHandler(async (event) => {
             // Reset for next turn
             fullText = '';
           } else {
-            // No tool use, we're done
+            // No client-side tool use, we're done
             break;
           }
+        }
+
+        // Save container ID for reuse in future turns
+        if (containerId && containerId !== chat.containerId) {
+          await db.update(tables.chats).set({ containerId }).where(eq(tables.chats.id, chat.id));
         }
 
         // Save assistant message to database
         const messageParts: MessagePart[] = [];
         if (reasoningText) {
           messageParts.push({ type: 'reasoning', text: reasoningText, state: 'done' });
+        }
+        // Add code execution parts
+        for (const ce of codeExecutions) {
+          messageParts.push(ce);
+        }
+        // Add file parts
+        for (const fp of fileParts) {
+          messageParts.push(fp);
         }
         if (fullText) {
           messageParts.push({ type: 'text', text: fullText });

--- a/packages/blog/server/api/chats/[id].post.ts
+++ b/packages/blog/server/api/chats/[id].post.ts
@@ -158,6 +158,7 @@ export default defineEventHandler(async (event) => {
         // Track code executions and files for message persistence
         const codeExecutions: CodeExecutionPart[] = [];
         const fileParts: FilePart[] = [];
+        const seenFileIds = new Set<string>();
 
         // Run up to 5 turns for tool use
         let turnCount = 0;
@@ -226,6 +227,66 @@ export default defineEventHandler(async (event) => {
                 currentServerToolName = block.name || null;
                 currentServerToolInput = '';
                 isServerToolBlock = true;
+              } else if (
+                block.type === 'bash_code_execution_tool_result' ||
+                block.type === 'text_editor_code_execution_tool_result'
+              ) {
+                // Code execution result — process inline for fast UI update
+                const result = block.content;
+                const stdout = result?.stdout || '';
+                const stderr = result?.stderr || '';
+                const exitCode = result?.return_code ?? 0;
+
+                // Collect files from this result block
+                const resultFiles: FilePart[] = [];
+                if (Array.isArray(result?.content)) {
+                  for (const item of result.content) {
+                    if (item.file_id && !seenFileIds.has(item.file_id)) {
+                      seenFileIds.add(item.file_id);
+                      let fileName = 'output';
+                      let mediaType = 'application/octet-stream';
+                      try {
+                        const meta = await betaClient.beta.files.retrieveMetadata(item.file_id, {
+                          betas: ['files-api-2025-04-14'],
+                        });
+                        fileName = meta.filename || fileName;
+                        mediaType = meta.mime_type || mediaType;
+                      } catch (e) {
+                        console.warn(
+                          `[chat] Failed to fetch file metadata for ${item.file_id}:`,
+                          e,
+                        );
+                      }
+
+                      const filePart: FilePart = {
+                        type: 'file',
+                        fileId: item.file_id,
+                        fileName,
+                        mediaType,
+                        url: `/api/artifacts/files/${item.file_id}`,
+                      };
+                      resultFiles.push(filePart);
+                      fileParts.push(filePart);
+                    }
+                  }
+                }
+
+                // Update the last running code execution with results
+                const lastRunning = codeExecutions.findLast((ce) => ce.state === 'running');
+                if (lastRunning) {
+                  lastRunning.stdout = stdout;
+                  lastRunning.stderr = stderr;
+                  lastRunning.exitCode = exitCode;
+                  lastRunning.state = 'done';
+                }
+
+                sendSSE(controller, {
+                  type: 'code_result',
+                  stdout,
+                  stderr,
+                  exitCode,
+                  files: resultFiles,
+                });
               }
             } else if (streamEvent.type === 'content_block_delta') {
               const delta = streamEvent.delta;
@@ -346,80 +407,12 @@ export default defineEventHandler(async (event) => {
             }
           }
 
-          // After stream completes, process the final message for code execution results
+          // After stream completes, extract container ID from final message
           try {
             const finalMessage = await streamResponse.finalMessage();
-
-            // Extract container ID from final message too
             if (finalMessage.container?.id && finalMessage.container.id !== containerId) {
               containerId = finalMessage.container.id;
               sendSSE(controller, { type: 'container', containerId: finalMessage.container.id });
-            }
-
-            // Process code execution result blocks from the final message
-            const seenFileIds = new Set<string>();
-
-            for (const block of finalMessage.content) {
-              if (
-                block.type === 'bash_code_execution_tool_result' ||
-                block.type === 'text_editor_code_execution_tool_result'
-              ) {
-                const result = block.content;
-                const stdout = result?.stdout || '';
-                const stderr = result?.stderr || '';
-                const exitCode = result?.return_code ?? 0;
-
-                // Collect files from this result block
-                const resultFiles: FilePart[] = [];
-                if (Array.isArray(result?.content)) {
-                  for (const item of result.content) {
-                    if (item.file_id && !seenFileIds.has(item.file_id)) {
-                      seenFileIds.add(item.file_id);
-                      let fileName = 'output';
-                      let mediaType = 'application/octet-stream';
-                      try {
-                        const meta = await betaClient.beta.files.retrieveMetadata(item.file_id, {
-                          betas: ['files-api-2025-04-14'],
-                        });
-                        fileName = meta.filename || fileName;
-                        mediaType = meta.mime_type || mediaType;
-                      } catch (e) {
-                        console.warn(
-                          `[chat] Failed to fetch file metadata for ${item.file_id}:`,
-                          e,
-                        );
-                      }
-
-                      const filePart: FilePart = {
-                        type: 'file',
-                        fileId: item.file_id,
-                        fileName,
-                        mediaType,
-                        url: `/api/artifacts/files/${item.file_id}`,
-                      };
-                      resultFiles.push(filePart);
-                      fileParts.push(filePart);
-                    }
-                  }
-                }
-
-                // Update the last running code execution with results
-                const lastRunning = codeExecutions.findLast((ce) => ce.state === 'running');
-                if (lastRunning) {
-                  lastRunning.stdout = stdout;
-                  lastRunning.stderr = stderr;
-                  lastRunning.exitCode = exitCode;
-                  lastRunning.state = 'done';
-                }
-
-                sendSSE(controller, {
-                  type: 'code_result',
-                  stdout,
-                  stderr,
-                  exitCode,
-                  files: resultFiles,
-                });
-              }
             }
           } catch (e) {
             // finalMessage() may fail if the stream was incomplete — log and continue

--- a/packages/blog/server/database/migrations/0001_classy_roughhouse.sql
+++ b/packages/blog/server/database/migrations/0001_classy_roughhouse.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "chats" ADD COLUMN "containerId" varchar(100);

--- a/packages/blog/server/database/migrations/0002_fix_search_vector_tsvector.sql
+++ b/packages/blog/server/database/migrations/0002_fix_search_vector_tsvector.sql
@@ -1,0 +1,23 @@
+-- Convert searchVector from text to tsvector type
+ALTER TABLE "document_chunks" ALTER COLUMN "searchVector" TYPE tsvector USING to_tsvector('english', COALESCE("searchVector", ''));--> statement-breakpoint
+
+-- Create trigger function to auto-generate tsvector from content + contextualContent
+CREATE OR REPLACE FUNCTION document_chunks_search_vector_update() RETURNS trigger AS $$
+BEGIN
+  NEW."searchVector" := to_tsvector('english', COALESCE(NEW.content, '') || ' ' || COALESCE(NEW."contextualContent", ''));
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+
+-- Create trigger on insert/update
+CREATE TRIGGER document_chunks_search_vector_trigger
+  BEFORE INSERT OR UPDATE OF content, "contextualContent"
+  ON "document_chunks"
+  FOR EACH ROW
+  EXECUTE FUNCTION document_chunks_search_vector_update();--> statement-breakpoint
+
+-- Backfill existing rows
+UPDATE "document_chunks" SET "searchVector" = to_tsvector('english', COALESCE(content, '') || ' ' || COALESCE("contextualContent", ''));--> statement-breakpoint
+
+-- Create GIN index for fast full-text search
+CREATE INDEX "document_chunks_search_vector_idx" ON "document_chunks" USING gin ("searchVector");

--- a/packages/blog/server/database/migrations/meta/0001_snapshot.json
+++ b/packages/blog/server/database/migrations/meta/0001_snapshot.json
@@ -1,0 +1,440 @@
+{
+  "id": "479ac545-e9f1-41de-ba00-b71a5ffe9b6e",
+  "prevId": "2736d886-fb09-4190-8841-7acc3bce7b31",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "containerId": {
+          "name": "containerId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chats_user_id_idx": {
+          "name": "chats_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_chunks": {
+      "name": "document_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunkIndex": {
+          "name": "chunkIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextualContent": {
+          "name": "contextualContent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "searchVector": {
+          "name": "searchVector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_chunks_document_id_idx": {
+          "name": "document_chunks_document_id_idx",
+          "columns": [
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_chunks_chunk_index_idx": {
+          "name": "document_chunks_chunk_index_idx",
+          "columns": [
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chunkIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_chunks_documentId_documents_id_fk": {
+          "name": "document_chunks_documentId_documents_id_fk",
+          "tableFrom": "document_chunks",
+          "tableTo": "documents",
+          "columnsFrom": ["documentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_slug_idx": {
+          "name": "documents_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "documents_slug_unique": {
+          "name": "documents_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_chat_id_idx": {
+          "name": "messages_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chatId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_chatId_chats_id_fk": {
+          "name": "messages_chatId_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_provider_id_idx": {
+          "name": "users_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.provider": {
+      "name": "provider",
+      "schema": "public",
+      "values": ["github"]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": ["user", "assistant"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/blog/server/database/migrations/meta/0002_snapshot.json
+++ b/packages/blog/server/database/migrations/meta/0002_snapshot.json
@@ -1,0 +1,440 @@
+{
+  "id": "1bc5232b-9f4e-4aa8-a898-132d5746d57c",
+  "prevId": "479ac545-e9f1-41de-ba00-b71a5ffe9b6e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "containerId": {
+          "name": "containerId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chats_user_id_idx": {
+          "name": "chats_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_chunks": {
+      "name": "document_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunkIndex": {
+          "name": "chunkIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextualContent": {
+          "name": "contextualContent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "searchVector": {
+          "name": "searchVector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_chunks_document_id_idx": {
+          "name": "document_chunks_document_id_idx",
+          "columns": [
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_chunks_chunk_index_idx": {
+          "name": "document_chunks_chunk_index_idx",
+          "columns": [
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chunkIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_chunks_documentId_documents_id_fk": {
+          "name": "document_chunks_documentId_documents_id_fk",
+          "tableFrom": "document_chunks",
+          "tableTo": "documents",
+          "columnsFrom": ["documentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_slug_idx": {
+          "name": "documents_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "documents_slug_unique": {
+          "name": "documents_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_chat_id_idx": {
+          "name": "messages_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chatId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_chatId_chats_id_fk": {
+          "name": "messages_chatId_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_provider_id_idx": {
+          "name": "users_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.provider": {
+      "name": "provider",
+      "schema": "public",
+      "values": ["github"]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": ["user", "assistant"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/blog/server/database/migrations/meta/_journal.json
+++ b/packages/blog/server/database/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1771287926435,
       "tag": "0001_classy_roughhouse",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1739721600000,
+      "tag": "0002_fix_search_vector_tsvector",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/blog/server/database/migrations/meta/_journal.json
+++ b/packages/blog/server/database/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1767419808786,
       "tag": "0000_secret_supernaut",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1771287926435,
+      "tag": "0001_classy_roughhouse",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/blog/server/database/schema.ts
+++ b/packages/blog/server/database/schema.ts
@@ -48,6 +48,7 @@ export const chats = pgTable(
       .$defaultFn(() => crypto.randomUUID()),
     title: varchar({ length: 200 }),
     userId: varchar({ length: 36 }).notNull(),
+    containerId: varchar({ length: 100 }),
     ...timestamps,
   },
   (table) => [index('chats_user_id_idx').on(table.userId)],

--- a/packages/blog/server/utils/ai/anthropic-beta-types.ts
+++ b/packages/blog/server/utils/ai/anthropic-beta-types.ts
@@ -52,11 +52,58 @@ export interface StreamableResponse {
   body?: ReadableStream | null;
 }
 
+/** Stream event types from the beta messages.stream() API */
+export interface BetaContentBlockStart {
+  type: 'content_block_start';
+  index: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  content_block: { type: string; id?: string; name?: string; [key: string]: any };
+}
+
+export interface BetaContentBlockDelta {
+  type: 'content_block_delta';
+  index: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delta: { type: string; [key: string]: any };
+}
+
+export interface BetaContentBlockStop {
+  type: 'content_block_stop';
+  index: number;
+}
+
+export interface BetaMessageStart {
+  type: 'message_start';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  message: { container?: { id: string }; [key: string]: any };
+}
+
+export interface BetaMessageDelta {
+  type: 'message_delta';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delta: { [key: string]: any };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  usage?: { [key: string]: any };
+}
+
+export type BetaStreamEvent =
+  | BetaContentBlockStart
+  | BetaContentBlockDelta
+  | BetaContentBlockStop
+  | BetaMessageStart
+  | BetaMessageDelta;
+
+/** Stream response from beta.messages.stream() */
+export interface BetaStreamResponse extends AsyncIterable<BetaStreamEvent> {
+  finalMessage(): Promise<CodeExecutionResponse>;
+}
+
 /** Typed wrapper for the Anthropic beta client methods we use */
 export interface AnthropicBetaClient {
   beta: {
     messages: {
       create(params: Record<string, unknown>): Promise<CodeExecutionResponse>;
+      stream(params: Record<string, unknown>): BetaStreamResponse;
     };
     files: {
       download(

--- a/packages/blog/server/utils/ai/skills-loader.ts
+++ b/packages/blog/server/utils/ai/skills-loader.ts
@@ -63,10 +63,10 @@ export function getSkillsForAPI(): Array<{
 }> {
   // Pre-built Anthropic document generation skills
   const prebuiltSkills = [
-    { type: 'anthropic', skill_id: 'create-pdf', version: 'latest' },
-    { type: 'anthropic', skill_id: 'create-pptx', version: 'latest' },
-    { type: 'anthropic', skill_id: 'create-xlsx', version: 'latest' },
-    { type: 'anthropic', skill_id: 'create-docx', version: 'latest' },
+    { type: 'anthropic', skill_id: 'pdf', version: 'latest' },
+    { type: 'anthropic', skill_id: 'pptx', version: 'latest' },
+    { type: 'anthropic', skill_id: 'xlsx', version: 'latest' },
+    { type: 'anthropic', skill_id: 'docx', version: 'latest' },
   ];
 
   const customSkills = loadCustomSkills().map((skill) => ({

--- a/packages/blog/server/utils/ai/skills-loader.ts
+++ b/packages/blog/server/utils/ai/skills-loader.ts
@@ -1,0 +1,122 @@
+import { readFileSync, readdirSync, existsSync } from 'fs';
+import { join } from 'path';
+import { getProjectRoot } from './skill-config';
+
+export interface CustomSkill {
+  name: string;
+  description: string;
+  body: string;
+}
+
+let cachedSkills: CustomSkill[] | null = null;
+
+/**
+ * Load custom SKILL.md files from .claude/skills/ directories.
+ * Results are cached at the module level (skills only change on deploy).
+ */
+export function loadCustomSkills(): CustomSkill[] {
+  if (cachedSkills) return cachedSkills;
+
+  const skills: CustomSkill[] = [];
+  const skillsDir = join(getProjectRoot(), '.claude', 'skills');
+
+  if (!existsSync(skillsDir)) {
+    cachedSkills = skills;
+    return skills;
+  }
+
+  const entries = readdirSync(skillsDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    const skillFile = join(skillsDir, entry.name, 'SKILL.md');
+    if (!existsSync(skillFile)) continue;
+
+    try {
+      const content = readFileSync(skillFile, 'utf-8');
+      const parsed = parseFrontmatter(content);
+      if (parsed.name && parsed.description) {
+        skills.push({
+          name: parsed.name,
+          description: parsed.description,
+          body: parsed.body,
+        });
+      }
+    } catch (e) {
+      console.warn(`[skills-loader] Failed to parse ${skillFile}:`, e);
+    }
+  }
+
+  cachedSkills = skills;
+  return skills;
+}
+
+/**
+ * Format loaded skills as container skills config for the Anthropic API.
+ * Returns pre-built Anthropic skills + custom skills from SKILL.md files.
+ */
+export function getSkillsForAPI(): Array<{
+  type: string;
+  skill_id: string;
+  version?: string;
+  instructions?: string;
+}> {
+  // Pre-built Anthropic document generation skills
+  const prebuiltSkills = [
+    { type: 'anthropic', skill_id: 'create-pdf', version: 'latest' },
+    { type: 'anthropic', skill_id: 'create-pptx', version: 'latest' },
+    { type: 'anthropic', skill_id: 'create-xlsx', version: 'latest' },
+    { type: 'anthropic', skill_id: 'create-docx', version: 'latest' },
+  ];
+
+  const customSkills = loadCustomSkills().map((skill) => ({
+    type: 'custom' as const,
+    skill_id: skill.name,
+    instructions: skill.body,
+  }));
+
+  return [...prebuiltSkills, ...customSkills];
+}
+
+/**
+ * Get a system prompt snippet describing available skills.
+ */
+export function getSkillsSystemPrompt(): string {
+  const skills = loadCustomSkills();
+  const skillList = skills.map((s) => `- ${s.name}: ${s.description}`).join('\n');
+
+  return `
+**CAPABILITIES:**
+You have code execution in a sandboxed container. You can:
+- Generate PDF, PPTX, XLSX, DOCX documents
+- Execute Python code for data analysis and visualization
+- Create charts, diagrams, and data exports
+
+${skillList ? `Custom skills available:\n${skillList}` : ''}`.trim();
+}
+
+/** Simple YAML frontmatter parser for SKILL.md files */
+function parseFrontmatter(content: string): {
+  name: string;
+  description: string;
+  body: string;
+} {
+  const match = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+  if (!match) return { name: '', description: '', body: content };
+
+  const frontmatter = match[1]!;
+  const body = match[2]!.trim();
+
+  let name = '';
+  let description = '';
+
+  for (const line of frontmatter.split('\n')) {
+    const nameMatch = line.match(/^name:\s*(.+)$/);
+    if (nameMatch) name = nameMatch[1]!.trim();
+
+    const descMatch = line.match(/^description:\s*(.+)$/);
+    if (descMatch) description = descMatch[1]!.trim();
+  }
+
+  return { name, description, body };
+}

--- a/packages/blog/shared/chat-types.ts
+++ b/packages/blog/shared/chat-types.ts
@@ -29,7 +29,31 @@ export interface ToolResultPart {
   result: unknown;
 }
 
-export type MessagePart = TextPart | ReasoningPart | ToolUsePart | ToolResultPart;
+export interface CodeExecutionPart {
+  type: 'code-execution';
+  code: string;
+  language: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  state: 'running' | 'done';
+}
+
+export interface FilePart {
+  type: 'file';
+  fileId: string;
+  fileName: string;
+  mediaType: string;
+  url: string;
+}
+
+export type MessagePart =
+  | TextPart
+  | ReasoningPart
+  | ToolUsePart
+  | ToolResultPart
+  | CodeExecutionPart
+  | FilePart;
 
 export interface ChatMessage {
   id: string;
@@ -88,6 +112,25 @@ export interface SSEToolEndEvent {
   result: unknown;
 }
 
+export interface SSECodeStartEvent {
+  type: 'code_start';
+  code: string;
+  language: string;
+}
+
+export interface SSECodeResultEvent {
+  type: 'code_result';
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  files: FilePart[];
+}
+
+export interface SSEContainerEvent {
+  type: 'container';
+  containerId: string;
+}
+
 export type SSEEvent =
   | SSETextEvent
   | SSEReasoningEvent
@@ -95,4 +138,7 @@ export type SSEEvent =
   | SSEErrorEvent
   | SSETitleEvent
   | SSEToolStartEvent
-  | SSEToolEndEvent;
+  | SSEToolEndEvent
+  | SSECodeStartEvent
+  | SSECodeResultEvent
+  | SSEContainerEvent;


### PR DESCRIPTION
## Summary

- **Code execution in chat** — Claude can now run Python/bash in sandboxed containers via Anthropic's Code Execution Tool beta, with container reuse across turns
- **Document generation skills** — PDF, PPTX, XLSX, DOCX generation via Anthropic Skills API (`pdf`, `pptx`, `xlsx`, `docx`) plus custom `.claude/skills/*/SKILL.md` support
- **BM25 search fix** — Migrated `searchVector` column from `text` to `tsvector` with auto-populate trigger and GIN index, fixing `ts_rank(text, tsquery) does not exist` error
- **Inline streaming of code results** — Code execution results are processed during streaming (`content_block_start`) instead of after `finalMessage()`, eliminating long spinner delays

## Changes

| Area | Files | What |
|------|-------|------|
| Shared types | `shared/chat-types.ts` | `CodeExecutionPart`, `FilePart`, new SSE events |
| Database | `schema.ts`, 2 migrations | `containerId` on chats, `searchVector` tsvector fix |
| Server | `chats/[id].post.ts` | Switched to `beta.messages.stream()` with code execution + skills |
| Server | `skills-loader.ts` | Loads `.claude/skills/*/SKILL.md` + pre-built Anthropic skills |
| Server | `anthropic-beta-types.ts` | Stream event types for beta API |
| Client | `useChat.ts` | Handles `code_start`, `code_result`, `container` SSE events |
| UI | `ChatCodeExecution.vue`, `ChatFile.vue` | New components for code output and file downloads |
| UI | `chat/[id].vue` | Renders new part types in message template |

## Test plan

- [ ] Existing tools still work: "What's the weather in NYC?", "Roll 4d6"
- [ ] Code execution: "Write Python to plot a sine wave" — spinner resolves when code finishes, not after full response
- [ ] Document generation: "Create a PDF about Vue best practices" — file appears with download link
- [ ] RAG search: "What posts about Claude?" — no more `ts_rank` error
- [ ] Container reuse: two code execution messages in same chat reuse container ID
- [ ] File download via `/api/artifacts/files/{id}` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)