### PR TITLE
feat: add GitHub dashboard with ECharts issue analytics

### DIFF
--- a/packages/blog/app/pages/admin/github.vue
+++ b/packages/blog/app/pages/admin/github.vue
@@ -1,0 +1,350 @@
+<script setup lang="ts">
+import type { GitHubDashboardData } from '~~/shared/github-types';
+
+definePageMeta({
+  middleware: 'auth',
+});
+
+const { data, status, refresh } = await useFetch<GitHubDashboardData>('/api/admin/github');
+
+// --- Chart options ---
+
+const issueFlowChartOption = computed(() => {
+  if (!data.value) return {};
+
+  const opened = data.value.opened_per_month;
+  const closed = data.value.closed_per_month;
+
+  // Merge and sort all month keys
+  const allMonths = [...new Set([...Object.keys(opened), ...Object.keys(closed)])].sort();
+
+  return {
+    title: {
+      text: 'Issues Opened vs Closed per Month',
+      left: 'center',
+      textStyle: { color: '#94a3b8' },
+    },
+    tooltip: { trigger: 'axis' },
+    legend: { bottom: 0, textStyle: { color: '#94a3b8' } },
+    grid: { left: 50, right: 30, top: 60, bottom: 50 },
+    xAxis: {
+      type: 'category',
+      data: allMonths,
+      axisLabel: { color: '#94a3b8', rotate: 45 },
+    },
+    yAxis: { type: 'value', axisLabel: { color: '#94a3b8' } },
+    series: [
+      {
+        name: 'Opened',
+        type: 'bar',
+        data: allMonths.map((m) => opened[m] || 0),
+        itemStyle: { color: '#38bdf8' }, // sky-400
+      },
+      {
+        name: 'Closed',
+        type: 'bar',
+        data: allMonths.map((m) => closed[m] || 0),
+        itemStyle: { color: '#22c55e' }, // green-500
+      },
+    ],
+  };
+});
+
+const labelPieChartOption = computed(() => {
+  if (!data.value) return {};
+
+  const labelData = data.value.labels.slice(0, 12).map((l) => ({
+    name: l.name,
+    value: l.count,
+    itemStyle: { color: l.color },
+  }));
+
+  return {
+    title: { text: 'Issues by Label', left: 'center', textStyle: { color: '#94a3b8' } },
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    legend: { orient: 'vertical', left: 'left', textStyle: { color: '#94a3b8' } },
+    series: [
+      {
+        type: 'pie',
+        radius: ['30%', '65%'],
+        center: ['55%', '55%'],
+        data: labelData,
+        label: { color: '#94a3b8' },
+        emphasis: {
+          itemStyle: { shadowBlur: 10, shadowOffsetX: 0, shadowColor: 'rgba(0,0,0,0.5)' },
+        },
+      },
+    ],
+  };
+});
+
+const timeToCloseChartOption = computed(() => {
+  if (!data.value) return {};
+
+  const closed = data.value.issues
+    .filter((i) => i.state === 'closed' && i.hours_to_close !== null)
+    .sort((a, b) => new Date(a.closed_at!).getTime() - new Date(b.closed_at!).getTime());
+
+  // Bucket into ranges for histogram
+  const buckets = [
+    { label: '< 1h', min: 0, max: 1 },
+    { label: '1-4h', min: 1, max: 4 },
+    { label: '4-24h', min: 4, max: 24 },
+    { label: '1-3d', min: 24, max: 72 },
+    { label: '3-7d', min: 72, max: 168 },
+    { label: '1-2w', min: 168, max: 336 },
+    { label: '2w-1m', min: 336, max: 720 },
+    { label: '1m+', min: 720, max: Infinity },
+  ];
+
+  const bucketCounts = buckets.map((b) => ({
+    label: b.label,
+    count: closed.filter((i) => i.hours_to_close! >= b.min && i.hours_to_close! < b.max).length,
+  }));
+
+  return {
+    title: { text: 'Time to Close Distribution', left: 'center', textStyle: { color: '#94a3b8' } },
+    tooltip: { trigger: 'axis' },
+    grid: { left: 50, right: 30, top: 60, bottom: 40 },
+    xAxis: {
+      type: 'category',
+      data: bucketCounts.map((b) => b.label),
+      axisLabel: { color: '#94a3b8' },
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Issues',
+      nameTextStyle: { color: '#94a3b8' },
+      axisLabel: { color: '#94a3b8' },
+    },
+    series: [
+      {
+        type: 'bar',
+        data: bucketCounts.map((b) => b.count),
+        itemStyle: {
+          color: {
+            type: 'linear',
+            x: 0,
+            y: 0,
+            x2: 1,
+            y2: 0,
+            colorStops: [
+              { offset: 0, color: '#38bdf8' },
+              { offset: 1, color: '#0ea5e9' },
+            ],
+          },
+        },
+      },
+    ],
+  };
+});
+
+const closeTimeScatterOption = computed(() => {
+  if (!data.value) return {};
+
+  const closed = data.value.issues
+    .filter((i) => i.state === 'closed' && i.hours_to_close !== null)
+    .map((i) => ({
+      value: [i.closed_at!, Math.min(i.hours_to_close!, 720)], // cap at 30 days for readability
+      name: `#${i.number}: ${i.title}`,
+      realHours: i.hours_to_close!,
+    }));
+
+  return {
+    title: { text: 'Close Time Over Time', left: 'center', textStyle: { color: '#94a3b8' } },
+    tooltip: {
+      trigger: 'item',
+      formatter: (params: { name: string; data: { realHours: number } }) => {
+        const hours = params.data.realHours;
+        const display = hours < 24 ? `${hours.toFixed(1)}h` : `${(hours / 24).toFixed(1)}d`;
+        return `${params.name}<br/>Close time: ${display}`;
+      },
+    },
+    grid: { left: 60, right: 30, top: 60, bottom: 40 },
+    xAxis: {
+      type: 'time',
+      axisLabel: { color: '#94a3b8' },
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Hours to close',
+      nameTextStyle: { color: '#94a3b8' },
+      axisLabel: { color: '#94a3b8' },
+    },
+    series: [
+      {
+        type: 'scatter',
+        data: closed,
+        symbolSize: 8,
+        itemStyle: { color: '#38bdf8', opacity: 0.7 },
+      },
+    ],
+  };
+});
+
+function formatDuration(hours: number | null): string {
+  if (hours === null) return '-';
+  if (hours < 1) return `${Math.round(hours * 60)}m`;
+  if (hours < 24) return `${hours.toFixed(1)}h`;
+  return `${(hours / 24).toFixed(1)}d`;
+}
+</script>
+
+<template>
+  <UContainer class="py-8">
+    <div class="max-w-7xl mx-auto space-y-6">
+      <!-- Header -->
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <UIcon name="i-simple-icons-github" class="w-8 h-8 text-primary" />
+          <div>
+            <h1 class="text-2xl font-bold">GitHub Dashboard</h1>
+            <p class="text-sm text-muted">{{ data?.repo }} - Issue analytics and metrics</p>
+          </div>
+        </div>
+        <UButton
+          icon="i-heroicons-arrow-path"
+          variant="ghost"
+          :loading="status === 'pending'"
+          @click="refresh()"
+        />
+      </div>
+
+      <!-- Loading -->
+      <div v-if="status === 'pending' && !data" class="flex justify-center py-16">
+        <UIcon name="i-heroicons-arrow-path" class="w-8 h-8 animate-spin text-primary" />
+      </div>
+
+      <template v-if="data">
+        <!-- Summary Cards -->
+        <div class="grid grid-cols-2 md:grid-cols-5 gap-4">
+          <UCard>
+            <div class="text-center">
+              <div class="text-3xl font-bold text-primary">{{ data.summary.total_issues }}</div>
+              <div class="text-sm text-muted">Total Issues</div>
+            </div>
+          </UCard>
+          <UCard>
+            <div class="text-center">
+              <div class="text-3xl font-bold text-warning">{{ data.summary.open_issues }}</div>
+              <div class="text-sm text-muted">Open</div>
+            </div>
+          </UCard>
+          <UCard>
+            <div class="text-center">
+              <div class="text-3xl font-bold text-success">{{ data.summary.closed_issues }}</div>
+              <div class="text-sm text-muted">Closed</div>
+            </div>
+          </UCard>
+          <UCard>
+            <div class="text-center">
+              <div class="text-3xl font-bold">
+                {{ formatDuration(data.summary.avg_hours_to_close) }}
+              </div>
+              <div class="text-sm text-muted">Avg Close Time</div>
+            </div>
+          </UCard>
+          <UCard>
+            <div class="text-center">
+              <div class="text-3xl font-bold">
+                {{ formatDuration(data.summary.median_hours_to_close) }}
+              </div>
+              <div class="text-sm text-muted">Median Close Time</div>
+            </div>
+          </UCard>
+        </div>
+
+        <!-- Charts Row 1: Issue Flow + Labels -->
+        <div class="grid md:grid-cols-2 gap-6">
+          <UCard>
+            <ClientOnly>
+              <VChart :option="issueFlowChartOption" style="height: 350px" autoresize />
+            </ClientOnly>
+          </UCard>
+          <UCard>
+            <ClientOnly>
+              <VChart :option="labelPieChartOption" style="height: 350px" autoresize />
+            </ClientOnly>
+          </UCard>
+        </div>
+
+        <!-- Charts Row 2: Time to Close -->
+        <div class="grid md:grid-cols-2 gap-6">
+          <UCard>
+            <ClientOnly>
+              <VChart :option="timeToCloseChartOption" style="height: 350px" autoresize />
+            </ClientOnly>
+          </UCard>
+          <UCard>
+            <ClientOnly>
+              <VChart :option="closeTimeScatterOption" style="height: 350px" autoresize />
+            </ClientOnly>
+          </UCard>
+        </div>
+
+        <!-- Recent Issues Table -->
+        <UCard>
+          <template #header>
+            <h3 class="font-semibold">Recent Issues</h3>
+          </template>
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="border-b border-muted">
+                  <th class="text-left py-2 px-3">#</th>
+                  <th class="text-left py-2 px-3">Title</th>
+                  <th class="text-left py-2 px-3">Status</th>
+                  <th class="text-left py-2 px-3">Labels</th>
+                  <th class="text-left py-2 px-3">Close Time</th>
+                  <th class="text-left py-2 px-3">Created</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="issue in data.issues.slice(0, 20)"
+                  :key="issue.number"
+                  class="border-b border-muted/50 hover:bg-muted/30"
+                >
+                  <td class="py-2 px-3 font-mono text-muted">{{ issue.number }}</td>
+                  <td class="py-2 px-3">
+                    <a
+                      :href="`https://github.com/${data.repo}/issues/${issue.number}`"
+                      target="_blank"
+                      class="hover:text-primary transition-colors"
+                    >
+                      {{ issue.title }}
+                    </a>
+                  </td>
+                  <td class="py-2 px-3">
+                    <UBadge :color="issue.state === 'open' ? 'warning' : 'success'" size="xs">
+                      {{ issue.state }}
+                    </UBadge>
+                  </td>
+                  <td class="py-2 px-3">
+                    <div class="flex flex-wrap gap-1">
+                      <UBadge v-for="label in issue.labels" :key="label" size="xs" variant="subtle">
+                        {{ label }}
+                      </UBadge>
+                    </div>
+                  </td>
+                  <td class="py-2 px-3 font-mono">
+                    {{ formatDuration(issue.hours_to_close) }}
+                  </td>
+                  <td class="py-2 px-3 text-muted">
+                    {{ new Date(issue.created_at).toLocaleDateString() }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </UCard>
+
+        <!-- Footer -->
+        <div class="text-xs text-muted text-center">
+          Data fetched at {{ new Date(data.fetched_at).toLocaleString() }}
+          · Source: GitHub REST API
+        </div>
+      </template>
+    </div>
+  </UContainer>
+</template>

--- a/packages/blog/app/pages/admin/index.vue
+++ b/packages/blog/app/pages/admin/index.vue
@@ -7,6 +7,12 @@ const { data: configData, status } = await useFetch('/api/admin/config');
 
 const adminPages = [
   {
+    title: 'GitHub Dashboard',
+    description: 'Issue analytics - time to close, labels, monthly trends, and more',
+    to: '/admin/github',
+    icon: 'i-simple-icons-github',
+  },
+  {
     title: 'RAG Admin',
     description: 'Contextual Hybrid Search System - manage documents, test search, run ingestion',
     to: '/admin/rag',

--- a/packages/blog/app/plugins/echarts.client.ts
+++ b/packages/blog/app/plugins/echarts.client.ts
@@ -1,0 +1,30 @@
+import { use } from 'echarts/core';
+import { CanvasRenderer } from 'echarts/renderers';
+import { BarChart, LineChart, PieChart, ScatterChart } from 'echarts/charts';
+import {
+  TitleComponent,
+  TooltipComponent,
+  LegendComponent,
+  GridComponent,
+  DataZoomComponent,
+  ToolboxComponent,
+} from 'echarts/components';
+import VChart from 'vue-echarts';
+
+export default defineNuxtPlugin((nuxtApp) => {
+  use([
+    CanvasRenderer,
+    BarChart,
+    LineChart,
+    PieChart,
+    ScatterChart,
+    TitleComponent,
+    TooltipComponent,
+    LegendComponent,
+    GridComponent,
+    DataZoomComponent,
+    ToolboxComponent,
+  ]);
+
+  nuxtApp.vueApp.component('VChart', VChart);
+});

--- a/packages/blog/nuxt.config.ts
+++ b/packages/blog/nuxt.config.ts
@@ -69,6 +69,8 @@ export default defineNuxtConfig({
     // Note: There's a pre-existing Vite 8 beta + debug ESM issue affecting chat pages
     '/chat': { ssr: false },
     '/chat/**': { ssr: false },
+    // Admin pages are authenticated, no SSR needed
+    '/admin/**': { ssr: false },
   },
 
   future: {

--- a/packages/blog/package.json
+++ b/packages/blog/package.json
@@ -39,6 +39,7 @@
     "braintrust": "^1.1.1",
     "date-fns": "^4.1.0",
     "drizzle-orm": "^0.44.7",
+    "echarts": "^6.0.0",
     "find-up": "^6.3.0",
     "mermaid": "^11.12.2",
     "nuxt": "^4.2.2",
@@ -50,6 +51,7 @@
     "shiki-stream": "^0.1.3",
     "tailwindcss": "^4.1.18",
     "ufo": "^1.6.1",
+    "vue-echarts": "^8.0.1",
     "zod": "^4.3.4"
   },
   "devDependencies": {

--- a/packages/blog/server/api/admin/github.get.ts
+++ b/packages/blog/server/api/admin/github.get.ts
@@ -1,0 +1,141 @@
+import type { GitHubDashboardData, GitHubIssue, GitHubLabel } from '~~/shared/github-types';
+
+interface GitHubApiIssue {
+  number: number;
+  title: string;
+  state: string;
+  labels: Array<{ name: string; color: string }>;
+  created_at: string;
+  closed_at: string | null;
+  pull_request?: unknown;
+}
+
+const REPO = 'ChrisTowles/blog';
+
+async function fetchAllIssues(): Promise<GitHubApiIssue[]> {
+  const all: GitHubApiIssue[] = [];
+  const perPage = 100;
+
+  for (const state of ['open', 'closed'] as const) {
+    let page = 1;
+    while (true) {
+      const url = `https://api.github.com/repos/${REPO}/issues?state=${state}&per_page=${perPage}&page=${page}&sort=created&direction=desc`;
+      const response = await fetch(url, {
+        headers: {
+          Accept: 'application/vnd.github.v3+json',
+          'User-Agent': 'chris-towles-blog',
+        },
+      });
+
+      if (!response.ok) {
+        throw createError({
+          statusCode: response.status,
+          statusMessage: `GitHub API error: ${response.statusText}`,
+        });
+      }
+
+      const issues: GitHubApiIssue[] = await response.json();
+      // Filter out pull requests (GitHub includes them in /issues)
+      const realIssues = issues.filter((i) => !i.pull_request);
+      all.push(...realIssues);
+
+      if (issues.length < perPage) break;
+      page++;
+    }
+  }
+
+  return all;
+}
+
+function computeHoursToClose(created: string, closed: string | null): number | null {
+  if (!closed) return null;
+  const diff = new Date(closed).getTime() - new Date(created).getTime();
+  return Math.round((diff / (1000 * 60 * 60)) * 10) / 10;
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 !== 0 ? sorted[mid]! : (sorted[mid - 1]! + sorted[mid]!) / 2;
+}
+
+function toMonthKey(dateStr: string): string {
+  return dateStr.slice(0, 7); // "2025-01"
+}
+
+export default defineEventHandler(async (event): Promise<GitHubDashboardData> => {
+  const session = await getUserSession(event);
+  if (!session.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' });
+  }
+
+  const rawIssues = await fetchAllIssues();
+
+  const issues: GitHubIssue[] = rawIssues.map((i) => ({
+    number: i.number,
+    title: i.title,
+    state: i.state as 'open' | 'closed',
+    labels: i.labels.map((l) => l.name),
+    created_at: i.created_at,
+    closed_at: i.closed_at,
+    hours_to_close: computeHoursToClose(i.created_at, i.closed_at),
+  }));
+
+  // Label counts
+  const labelMap = new Map<string, { color: string; count: number }>();
+  for (const raw of rawIssues) {
+    for (const label of raw.labels) {
+      const existing = labelMap.get(label.name);
+      if (existing) {
+        existing.count++;
+      } else {
+        labelMap.set(label.name, { color: `#${label.color}`, count: 1 });
+      }
+    }
+  }
+  const labels: GitHubLabel[] = Array.from(labelMap.entries())
+    .map(([name, { color, count }]) => ({ name, color, count }))
+    .sort((a, b) => b.count - a.count);
+
+  // Summary
+  const closedIssues = issues.filter((i) => i.state === 'closed');
+  const closeTimes = closedIssues
+    .map((i) => i.hours_to_close)
+    .filter((h): h is number => h !== null);
+
+  const summary = {
+    total_issues: issues.length,
+    open_issues: issues.filter((i) => i.state === 'open').length,
+    closed_issues: closedIssues.length,
+    avg_hours_to_close:
+      closeTimes.length > 0
+        ? Math.round((closeTimes.reduce((a, b) => a + b, 0) / closeTimes.length) * 10) / 10
+        : null,
+    median_hours_to_close: median(closeTimes),
+  };
+
+  // Monthly aggregation
+  const closedPerMonth: Record<string, number> = {};
+  const openedPerMonth: Record<string, number> = {};
+
+  for (const issue of issues) {
+    const openMonth = toMonthKey(issue.created_at);
+    openedPerMonth[openMonth] = (openedPerMonth[openMonth] || 0) + 1;
+
+    if (issue.closed_at) {
+      const closeMonth = toMonthKey(issue.closed_at);
+      closedPerMonth[closeMonth] = (closedPerMonth[closeMonth] || 0) + 1;
+    }
+  }
+
+  return {
+    repo: REPO,
+    issues,
+    labels,
+    summary,
+    closed_per_month: closedPerMonth,
+    opened_per_month: openedPerMonth,
+    fetched_at: new Date().toISOString(),
+  };
+});

--- a/packages/blog/shared/github-types.ts
+++ b/packages/blog/shared/github-types.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared types for GitHub dashboard
+ * Used by both client and server
+ */
+
+export interface GitHubIssue {
+  number: number;
+  title: string;
+  state: 'open' | 'closed';
+  labels: string[];
+  created_at: string;
+  closed_at: string | null;
+  /** Time to close in hours, null if still open */
+  hours_to_close: number | null;
+}
+
+export interface GitHubLabel {
+  name: string;
+  color: string;
+  count: number;
+}
+
+export interface GitHubDashboardData {
+  repo: string;
+  issues: GitHubIssue[];
+  labels: GitHubLabel[];
+  summary: {
+    total_issues: number;
+    open_issues: number;
+    closed_issues: number;
+    avg_hours_to_close: number | null;
+    median_hours_to_close: number | null;
+  };
+  /** Issues closed per month: { "2025-01": 5, ... } */
+  closed_per_month: Record<string, number>;
+  /** Issues opened per month */
+  opened_per_month: Record<string, number>;
+  fetched_at: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       drizzle-orm:
         specifier: ^0.44.7
         version: 0.44.7(@opentelemetry/api@1.9.0)(better-sqlite3@12.5.0)(pg@8.16.3)(postgres@3.4.8)
+      echarts:
+        specifier: ^6.0.0
+        version: 6.0.0
       find-up:
         specifier: ^6.3.0
         version: 6.3.0
@@ -123,6 +126,9 @@ importers:
       ufo:
         specifier: ^1.6.1
         version: 1.6.2
+      vue-echarts:
+        specifier: ^8.0.1
+        version: 8.0.1(echarts@6.0.0)(vue@3.5.26(typescript@5.9.3))
       zod:
         specifier: ^4.3.4
         version: 4.3.5
@@ -365,6 +371,7 @@ packages:
   '@aws-sdk/middleware-websocket@3.965.0':
     resolution: {integrity: sha512-BGU92StrWF0EJj8jX5EFvRkX9z4/CVIZfON0nWow8gb5ouKwz47o1rO9CP/k2b3F6g134/0XqwXvrUgIWfjJeA==}
     engines: {node: '>= 14.0.0'}
+    deprecated: Please update your @aws-sdk client to a more recent version, such as https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.982.0, if using browser-based WebSocket bidirectional streaming.
 
   '@aws-sdk/nested-clients@3.965.0':
     resolution: {integrity: sha512-muNVUjUEU+/KLFrLzQ8PMXyw4+a/MP6t4GIvwLtyx/kH0rpSy5s0YmqacMXheuIe6F/5QT8uksXGNAQenitkGQ==}
@@ -4870,6 +4877,9 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
+  echarts@6.0.0:
+    resolution: {integrity: sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==}
+
   editorconfig@1.0.4:
     resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
     engines: {node: '>=14'}
@@ -5367,6 +5377,7 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   global-directory@4.0.1:
@@ -7141,6 +7152,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prettier@2.8.8:
@@ -7910,6 +7922,7 @@ packages:
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -8005,6 +8018,9 @@ packages:
 
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
+  tslib@2.3.0:
+    resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
 
   tslib@2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
@@ -8577,6 +8593,12 @@ packages:
   vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
 
+  vue-echarts@8.0.1:
+    resolution: {integrity: sha512-23rJTFLu1OUEGRWjJGmdGt8fP+8+ja1gVgzMYPIPaHWpXegcO1viIAaeu2H4QHESlVeHzUAHIxKXGrwjsyXAaA==}
+    peerDependencies:
+      echarts: ^6.0.0
+      vue: ^3.3.0
+
   vue-flow-layout@0.2.0:
     resolution: {integrity: sha512-zKgsWWkXq0xrus7H4Mc+uFs1ESrmdTXlO0YNbR6wMdPaFvosL3fMB8N7uTV308UhGy9UvTrGhIY7mVz9eN+L0Q==}
 
@@ -8814,6 +8836,9 @@ packages:
 
   zod@4.3.5:
     resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
+
+  zrender@6.0.0:
+    resolution: {integrity: sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -14484,6 +14509,11 @@ snapshots:
       safe-buffer: 5.2.1
     optional: true
 
+  echarts@6.0.0:
+    dependencies:
+      tslib: 2.3.0
+      zrender: 6.0.0
+
   editorconfig@1.0.4:
     dependencies:
       '@one-ini/wasm': 0.1.1
@@ -18545,6 +18575,8 @@ snapshots:
 
   tslib@1.14.1: {}
 
+  tslib@2.3.0: {}
+
   tslib@2.4.0: {}
 
   tslib@2.8.1: {}
@@ -19260,6 +19292,11 @@ snapshots:
 
   vue-devtools-stub@0.1.0: {}
 
+  vue-echarts@8.0.1(echarts@6.0.0)(vue@3.5.26(typescript@5.9.3)):
+    dependencies:
+      echarts: 6.0.0
+      vue: 3.5.26(typescript@5.9.3)
+
   vue-flow-layout@0.2.0: {}
 
   vue-resize@2.0.0-alpha.1(vue@3.5.26(typescript@5.9.3)):
@@ -19480,6 +19517,10 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.5: {}
+
+  zrender@6.0.0:
+    dependencies:
+      tslib: 2.3.0
 
   zwitch@2.0.4: {}
 


### PR DESCRIPTION
Add an admin dashboard page at /admin/github that visualizes GitHub
issue data using Apache ECharts. Includes opened vs closed per month,
label distribution pie chart, time-to-close histogram, scatter plot
of close times, and a recent issues table with summary stats.

https://claude.ai/code/session_013pvtKWw57KRPTqkMgfj3pq

Closes #174