### PR TITLE
fix(deploy): increase Node heap for Docker build + polish loan demo UX

### DIFF
--- a/infra/container/blog.Dockerfile
+++ b/infra/container/blog.Dockerfile
@@ -35,6 +35,7 @@ ENV NUXT_CONTENT_DATABASE=false
 ENV NITRO_PRESET=node-server
 
 # Build the Nuxt application
+ENV NODE_OPTIONS="--max-old-space-size=8192"
 RUN cd /app && pnpm --filter @chris-towles/blog exec nuxt build
 
 # Production stage - use Node for runtime stability

--- a/packages/blog/app/pages/loan/[id]/index.vue
+++ b/packages/blog/app/pages/loan/[id]/index.vue
@@ -15,8 +15,8 @@ definePageMeta({
 });
 
 useSeoMeta({
-  title: 'Home Loan Application',
-  description: 'AI-powered home loan intake chat',
+  title: 'Agentic Loan Workflow — Intake',
+  description: 'Demo: AI-powered conversational data collection for loan applications',
 });
 
 const route = useRoute();
@@ -70,9 +70,13 @@ function submitForReview() {
     <div class="shrink-0 border-b border-default px-4 py-4">
       <UContainer class="max-w-4xl">
         <div class="mb-4">
-          <h1 class="text-3xl font-bold text-highlighted">Home Loan Application</h1>
-          <p class="text-muted mt-2">
-            AI-powered loan application with multi-agent approval workflow
+          <div class="flex items-center gap-2 mb-1">
+            <UBadge color="warning" variant="subtle" label="Demo" size="sm" />
+            <h1 class="text-3xl font-bold text-highlighted">Agentic Loan Workflow</h1>
+          </div>
+          <p class="text-muted mt-1 text-sm">
+            Step 1: AI collects your application via chat. Answer naturally — the agent extracts
+            structured data.
           </p>
         </div>
         <LoanProgress :application-data="applicationData" />

--- a/packages/blog/app/pages/loan/[id]/review.vue
+++ b/packages/blog/app/pages/loan/[id]/review.vue
@@ -15,8 +15,8 @@ definePageMeta({
 });
 
 useSeoMeta({
-  title: 'Loan Review',
-  description: 'AI-powered multi-agent loan review',
+  title: 'Agentic Loan Workflow — Review',
+  description: 'Demo: three independent AI agents review, human makes final decision',
 });
 
 const route = useRoute();
@@ -147,8 +147,14 @@ onMounted(() => {
   <div class="h-full overflow-y-auto">
     <UContainer class="py-8 max-w-4xl">
       <div class="mb-8">
-        <h1 class="text-3xl font-bold text-highlighted">Loan Review</h1>
-        <p class="text-muted mt-2">Multi-agent review of your loan application</p>
+        <div class="flex items-center gap-2 mb-1">
+          <UBadge color="warning" variant="subtle" label="Demo" size="sm" />
+          <h1 class="text-3xl font-bold text-highlighted">Agentic Loan Review</h1>
+        </div>
+        <p class="text-muted mt-1 text-sm">
+          Step 2: Three independent AI agents review the application. A human makes the final
+          decision.
+        </p>
       </div>
 
       <!-- Application Data Summary -->

--- a/packages/blog/app/pages/loan/index.vue
+++ b/packages/blog/app/pages/loan/index.vue
@@ -8,8 +8,8 @@ definePageMeta({
 });
 
 useSeoMeta({
-  title: 'Home Loan Application Demo',
-  description: 'AI-powered home loan application with multi-agent approval workflow',
+  title: 'Agentic Loan Workflow Demo',
+  description: 'Demo: multi-agent AI orchestration with human-in-the-loop approval for home loans',
 });
 
 const toast = useToast();
@@ -35,23 +35,40 @@ async function startApplication() {
 <template>
   <UContainer :data-testid="TEST_IDS.LOAN.PAGE" class="py-8 max-w-4xl">
     <div class="mb-8">
-      <h1 class="text-3xl font-bold text-highlighted">Home Loan Application</h1>
-      <p class="text-muted mt-2">AI-powered loan application with multi-agent approval workflow</p>
+      <div class="flex items-center gap-2 mb-1">
+        <UBadge color="warning" variant="subtle" label="Demo" size="sm" />
+        <h1 class="text-3xl font-bold text-highlighted">Agentic Loan Workflow</h1>
+      </div>
+      <p class="text-muted mt-2">
+        A demo of multi-agent AI orchestration with human-in-the-loop approval
+      </p>
     </div>
 
-    <div class="flex flex-col items-center gap-6 py-16">
-      <UIcon name="i-lucide-building-2" class="text-6xl text-primary" />
-      <p class="text-lg text-center max-w-md">
-        Start a conversation with our AI loan officer to apply for a home loan. Three independent
-        reviewers will evaluate your application.
-      </p>
+    <div class="flex flex-col items-center gap-6 py-12">
+      <UIcon name="i-lucide-bot" class="text-6xl text-primary" />
+      <div class="text-center max-w-lg space-y-3">
+        <p class="text-lg">
+          This demo showcases an agentic workflow where AI collects data via chat, three independent
+          AI agents review the application, and a human makes the final decision.
+        </p>
+        <div class="flex flex-wrap justify-center gap-2 text-sm">
+          <UBadge color="neutral" variant="outline" label="Conversational intake" />
+          <UBadge color="neutral" variant="outline" label="3 AI reviewers" />
+          <UBadge color="neutral" variant="outline" label="Real-time SSE streaming" />
+          <UBadge color="neutral" variant="outline" label="Human-in-the-loop" />
+        </div>
+      </div>
       <UButton
         :data-testid="TEST_IDS.LOAN.START_BUTTON"
-        label="Start Application"
+        label="Try the Demo"
         size="lg"
+        icon="i-lucide-play"
         :loading="loading"
         @click="startApplication"
       />
+      <p class="text-xs text-muted">
+        No real financial data is processed. This is a technical demo.
+      </p>
     </div>
   </UContainer>
 </template>

--- a/packages/blog/content/2.blog/20260225.multi-agent-loan-approval-human-in-the-loop.md
+++ b/packages/blog/content/2.blog/20260225.multi-agent-loan-approval-human-in-the-loop.md
@@ -1,0 +1,143 @@
+---
+title: 'Building a Multi-Agent Loan Approval System with Human-in-the-Loop'
+description: 'A demo of multi-agent AI orchestration where three specialized reviewers analyze loan applications independently, stream results in real-time via SSE, and a human makes the final call.'
+date: '2026-02-25'
+badge:
+  label: 'Architecture'
+image:
+  src: '/images/todo-place-holder-image.png'
+  alt: 'Multi-agent loan approval workflow with AI reviewers and human decision'
+authors:
+  - name: Chris Towles
+    to: https://twitter.com/Chris_Towles
+    avatar:
+      src: /images/ctowles-profile-512x512.png
+---
+
+## What I Built
+
+A home loan application workflow where AI agents review applications but a human makes the final call. Three specialized AI reviewers analyze every application independently, then a human approves, denies, or flags it — the AI advises, it doesn't decide.
+
+This is a demo/playground, not production financial software. But it demonstrates a pattern that matters: multi-agent AI systems that keep humans in the decision loop.
+
+## The Flow
+
+```
+Intake (chat) → AI Review (3 agents, streaming) → Human Decision
+     ↑                                                    |
+     └──────────── Re-review ──────────────────────────────┘
+```
+
+### 1. Intake — Conversational Data Collection
+
+The applicant chats with an AI assistant that collects loan details naturally. No forms — just conversation. The AI uses tool calls behind the scenes to extract structured data (name, income, employment, property details, credit score range) and updates a progress bar in real time.
+
+<!-- TODO: add screenshot of /loan/[id] — chat interface with progress bar -->
+
+Once all 12 fields are collected, a "Submit for Review" button appears.
+
+### 2. Multi-Agent Review — Three Independent AI Reviewers
+
+Submitting triggers three AI reviewers that run sequentially, each streaming their analysis in real-time via SSE:
+
+- **The Bank — Financial Risk**: Evaluates DTI ratio, LTV ratio, credit score, income stability. Conservative risk assessment focused on regulatory compliance.
+- **Loan Market — Deal Structure**: Analyzes the deal from a market perspective — is the property fairly valued? Is the loan amount reasonable for the area?
+- **Background Checks — Fraud Detection**: Looks for inconsistencies in the application data. Cross-references employment claims, income vs. debt ratios, and flags suspicious patterns.
+
+Each reviewer uses a custom system prompt and independently decides: **approve**, **deny**, or **flag**.
+
+#### The Reviewer Prompts
+
+Each reviewer's personality and evaluation criteria live in a [Claude Code Skills](https://docs.anthropic.com/en/docs/claude-code/skills) markdown file. The server loads these at review time as the system prompt for each agent call. Here's the key section from each:
+
+**[The Bank — Financial Risk](https://github.com/ChrisTowles/blog/blob/main/.claude/skills/loan-the-bank/SKILL.md)** evaluates DTI, LTV, credit score, and employment stability. It's told to be conservative: "It is MORE IMPORTANT to flag issues than to approve." Red flags include DTI > 43%, LTV > 95%, subprime credit scores, and employment under 2 years.
+
+**[Loan Market — Deal Structure](https://github.com/ChrisTowles/blog/blob/main/.claude/skills/loan-market/SKILL.md)** focuses on the deal economics, not the borrower. It checks property value reasonableness, jumbo loan thresholds, down payment signals, and property type risk profiles. "Focus on the deal economics. Be specific."
+
+**[Background Checks — Fraud Detection](https://github.com/ChrisTowles/blog/blob/main/.claude/skills/loan-background/SKILL.md)** is the skeptic: "Assume nothing. Question everything." It looks for income/employment mismatches, suspiciously round numbers, mathematically impossible combinations, and vague employer names.
+
+All three share the same output format — a JSON object with `decision`, `flags`, and `analysis` — but their evaluation criteria and tone are completely different. This is what makes the multi-agent approach interesting: same input, different lenses.
+
+<!-- TODO: add screenshot of /loan/[id]/review — review cards streaming in -->
+
+### 3. Human Decision — AI Recommends, Human Decides
+
+After all three reviewers complete, the system shows the AI's aggregate recommendation but keeps the status as "reviewing." The application doesn't move forward until a human clicks Approve, Deny, or Flag.
+
+<!-- TODO: add screenshot of AI recommendation card with Approve/Deny/Flag buttons -->
+
+This is the key design decision. Even if all three AI agents approve unanimously, a human must confirm. The AI recommendation is clearly labeled as advisory.
+
+After deciding, the human can still change their decision or send the application back for a fresh re-review.
+
+<!-- TODO: add screenshot of final decision card with change decision options -->
+
+### 4. Admin Dashboard
+
+An admin view shows all applications across all users with status counts and a table for quick navigation.
+
+<!-- TODO: add screenshot of /admin/loans dashboard -->
+
+### 5. Re-review
+
+Hit "Re-review" and the system clears all AI reviews, resets to intake status, and sends the user back to the chat. The application data is preserved — they can modify answers or submit again for a fresh set of AI reviews.
+
+## Architecture
+
+### Tech Stack
+
+- **Frontend**: Nuxt 4, Vue 3, Nuxt UI
+- **Backend**: Nitro server routes, Drizzle ORM, PostgreSQL
+- **AI**: Anthropic Claude (via SDK), three independent agent calls
+- **Streaming**: Server-Sent Events (SSE) for real-time review streaming
+- **Hosting**: GCP Cloud Run
+
+### Status Model
+
+```
+intake → reviewing → approved | denied | flagged
+  ↑                       |
+  └──── re-review ────────┘
+```
+
+- `intake` — collecting application data via chat
+- `reviewing` — AI agents have run, waiting for human decision
+- `approved` / `denied` / `flagged` — human has decided
+
+### Key Design Choices
+
+**AI agents don't share context.** Each reviewer gets the same application data independently. They can't see each other's analysis. This prevents groupthink and ensures genuinely independent assessments.
+
+**Streaming, not batch.** Reviews stream token-by-token via SSE so the user watches each analysis build in real time. This matters for trust — you see the reasoning unfold, not just a verdict.
+
+**Human-in-the-loop is mandatory, not optional.** The server never sets a final status automatically. The `submit` endpoint leaves status as `reviewing` after AI completes. Only the `status.patch` endpoint (triggered by human click) sets `approved`/`denied`/`flagged`.
+
+**Clean analysis, not raw JSON.** During streaming, the user sees plain text as the LLM generates it. Once complete, the server parses the structured JSON response and replaces the raw output with clean analysis text. A "Show raw response" toggle is available for debugging.
+
+### How Skills Become System Prompts
+
+The reviewer prompts are loaded at runtime from markdown files on disk — not hardcoded in the server code. A utility function strips the YAML frontmatter and passes the body as the `system` parameter to the Anthropic SDK:
+
+```typescript
+// server/utils/ai/loan-review-utils.ts
+const systemPrompt = loadApproverPrompt(reviewer);
+
+const streamResponse = client.messages.stream({
+  model: config.public.model,
+  max_tokens: 4096,
+  system: systemPrompt,
+  messages: [{ role: 'user', content: formattedApplication }],
+});
+```
+
+Each reviewer gets the same formatted application data as the user message. The skill file controls their perspective — the bank is conservative, the market analyst cares about deal structure, the fraud investigator is deeply skeptical.
+
+This means you can tweak a reviewer's personality or evaluation criteria by editing a markdown file. No code changes, no redeployment.
+
+## What This Demonstrates
+
+1. **Multi-agent orchestration** — Multiple specialized AI agents working on the same input independently
+2. **Human-in-the-loop** — AI as advisor, not decision-maker
+3. **Real-time streaming** — SSE for progressive UI updates during AI processing
+4. **Conversational data collection** — Chat-based intake instead of traditional forms
+5. **Tool use** — AI extracts structured data from natural language via function calling


### PR DESCRIPTION
## Summary
- Fix CI deploy OOM: Nitro server bundling hit ~3.8GB heap limit during Docker build. Added `NODE_OPTIONS=--max-old-space-size=8192` to builder stage.
- Rebrand loan pages as "Agentic Loan Workflow" demo with badges, step descriptions, and updated SEO meta.

## Test plan
- [ ] Deploy workflow succeeds (no OOM during Nitro build)
- [ ] Loan pages render with updated copy and badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)