### PR TITLE
feat: Add Google Analytics via nuxt-gtag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,9 @@ ANTHROPIC_API_KEY=
 # Local dev uses request origin automatically; this is for the Agent SDK tools
 # NUXT_PUBLIC_SITE_URL=http://localhost:3000
 
+# Google Analytics 4 Measurement ID (optional — analytics disabled if unset)
+# NUXT_PUBLIC_GTAG_ID=G-XXXXXXXXXX
+
 #### Github OAuth apps###
 # https://github.com/settings/developers
 # GitHub OAuth client ID

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -55,25 +55,26 @@ module "cloud_sql" {
 module "cloud_run" {
   source = "../../modules/cloud-run"
 
-  project_id    = var.project_id
-  region        = var.region
-  container_image               = var.container_image
-  service_account_email         = module.shared.service_account_email
-  database_connection_secret_id = module.cloud_sql.connection_string_secret_id
-  cloud_sql_connection_name     = module.cloud_sql.instance_connection_name
+  project_id                           = var.project_id
+  region                               = var.region
+  container_image                      = var.container_image
+  service_account_email                = module.shared.service_account_email
+  database_connection_secret_id        = module.cloud_sql.connection_string_secret_id
+  cloud_sql_connection_name            = module.cloud_sql.instance_connection_name
   anthropic_api_key_secret_id          = module.shared.anthropic_api_key_secret_id
   session_password_secret_id           = module.shared.session_password_secret_id
   aws_access_key_id_secret_id          = module.shared.aws_access_key_id_secret_id
   aws_secret_access_key_secret_id      = module.shared.aws_secret_access_key_secret_id
-  github_oauth_client_id_secret_id      = module.shared.github_oauth_client_id_secret_id
-  github_oauth_client_secret_secret_id  = module.shared.github_oauth_client_secret_secret_id
-  braintrust_api_key_secret_id          = module.shared.braintrust_api_key_secret_id
-  braintrust_project_name               = "blog-prod"
-  site_url                              = var.site_url
-  cpu_limit                     = "1"
-  memory_limit                  = "512Mi"
-  min_instances                 = 0
-  max_instances                 = 2
+  github_oauth_client_id_secret_id     = module.shared.github_oauth_client_id_secret_id
+  github_oauth_client_secret_secret_id = module.shared.github_oauth_client_secret_secret_id
+  braintrust_api_key_secret_id         = module.shared.braintrust_api_key_secret_id
+  braintrust_project_name              = "blog-prod"
+  site_url                             = var.site_url
+  cpu_limit                            = "1"
+  memory_limit                         = "512Mi"
+  min_instances                        = 0
+  max_instances                        = 2
+  additional_env_vars                  = { NUXT_PUBLIC_GTAG_ID = var.gtag_id }
 
   depends_on = [module.cloud_sql]
 }

--- a/infra/terraform/environments/prod/variables.tf
+++ b/infra/terraform/environments/prod/variables.tf
@@ -20,3 +20,9 @@ variable "site_url" {
   type        = string
   default     = "https://chris.towles.dev"
 }
+
+variable "gtag_id" {
+  description = "Google Analytics 4 Measurement ID"
+  type        = string
+  default     = ""
+}

--- a/infra/terraform/environments/staging/main.tf
+++ b/infra/terraform/environments/staging/main.tf
@@ -153,23 +153,24 @@ resource "google_cloud_scheduler_job" "stop_sql_nightly" {
 module "cloud_run" {
   source = "../../modules/cloud-run"
 
-  project_id    = var.project_id
-  region        = var.region
-  container_image               = var.container_image
-  service_account_email         = module.shared.service_account_email
-  database_connection_secret_id = module.cloud_sql.connection_string_secret_id
-  cloud_sql_connection_name     = module.cloud_sql.instance_connection_name
+  project_id                           = var.project_id
+  region                               = var.region
+  container_image                      = var.container_image
+  service_account_email                = module.shared.service_account_email
+  database_connection_secret_id        = module.cloud_sql.connection_string_secret_id
+  cloud_sql_connection_name            = module.cloud_sql.instance_connection_name
   anthropic_api_key_secret_id          = module.shared.anthropic_api_key_secret_id
   session_password_secret_id           = module.shared.session_password_secret_id
   aws_access_key_id_secret_id          = module.shared.aws_access_key_id_secret_id
   aws_secret_access_key_secret_id      = module.shared.aws_secret_access_key_secret_id
-  github_oauth_client_id_secret_id      = module.shared.github_oauth_client_id_secret_id
-  github_oauth_client_secret_secret_id  = module.shared.github_oauth_client_secret_secret_id
-  braintrust_api_key_secret_id          = module.shared.braintrust_api_key_secret_id
-  braintrust_project_name               = "blog-stage"
-  site_url                              = var.site_url
-  min_instances                 = 0
-  max_instances                 = 2
+  github_oauth_client_id_secret_id     = module.shared.github_oauth_client_id_secret_id
+  github_oauth_client_secret_secret_id = module.shared.github_oauth_client_secret_secret_id
+  braintrust_api_key_secret_id         = module.shared.braintrust_api_key_secret_id
+  braintrust_project_name              = "blog-stage"
+  site_url                             = var.site_url
+  min_instances                        = 0
+  max_instances                        = 2
+  additional_env_vars                  = { NUXT_PUBLIC_GTAG_ID = var.gtag_id }
 
   depends_on = [module.cloud_sql]
 }

--- a/infra/terraform/environments/staging/variables.tf
+++ b/infra/terraform/environments/staging/variables.tf
@@ -19,7 +19,10 @@ variable "site_url" {
   description = "Public URL for staging site"
   type        = string
   default     = "https://staging-chris.towles.dev/"
-
 }
 
-
+variable "gtag_id" {
+  description = "Google Analytics 4 Measurement ID"
+  type        = string
+  default     = ""
+}

--- a/packages/blog/app/components/CodeRunner.vue
+++ b/packages/blog/app/components/CodeRunner.vue
@@ -59,6 +59,10 @@ onMounted(() => {
 const isRunning = computed(() => status.value === 'executing' || status.value === 'streaming');
 
 function handleRun() {
+  const { gtag } = useGtag();
+  gtag('event', 'code_runner_execute', {
+    language: language.value,
+  });
   execute(props.prompt);
 }
 

--- a/packages/blog/app/pages/blog/[slug].vue
+++ b/packages/blog/app/pages/blog/[slug].vue
@@ -30,6 +30,14 @@ if (post.value.image?.src) {
     headline: 'Blog',
   });
 }
+
+onMounted(() => {
+  const { gtag } = useGtag();
+  gtag('event', 'blog_post_read', {
+    post_title: post.value?.title,
+    post_slug: route.params.slug,
+  });
+});
 </script>
 
 <template>

--- a/packages/blog/app/pages/chat/index.vue
+++ b/packages/blog/app/pages/chat/index.vue
@@ -29,6 +29,8 @@ async function createChat(prompt: string) {
     });
     console.log('chat', chat);
     refreshNuxtData('chats');
+    const { gtag } = useGtag();
+    gtag('event', 'chat_started');
     await navigateTo(`/chat/${chat.id}`);
     // no loading state to reset, because we are navigating away.
   } catch (error) {

--- a/packages/blog/nuxt.config.ts
+++ b/packages/blog/nuxt.config.ts
@@ -23,6 +23,23 @@ export default defineNuxtConfig({
     '@nuxt/test-utils/module',
   ],
 
+  gtag: {
+    enabled: !!process.env.NUXT_PUBLIC_GTAG_ID,
+    id: process.env.NUXT_PUBLIC_GTAG_ID,
+    initCommands: [
+      [
+        'consent',
+        'default',
+        {
+          ad_user_data: 'denied',
+          ad_personalization: 'denied',
+          ad_storage: 'denied',
+          analytics_storage: 'denied',
+        },
+      ],
+    ],
+  },
+
   devtools: {
     enabled: true,
 


### PR DESCRIPTION
## Summary

Automated implementation for: **feat: Add Google Analytics via nuxt-gtag**

Closes #180

## Pipeline Artifacts

- Research: `.auto-claude/issue-180/research.md`
- Plan: `.auto-claude/issue-180/plan.md`
- Implementation Plan: `.auto-claude/issue-180/plan-implementation.md`
- Review: `.auto-claude/issue-180/review.md`

## Review Summary

# Review: Add Google Analytics via nuxt-gtag (#180)

## Status: PASS

## Issues found

None. No fixes needed.

## Automated checks

| Check | Result |
|-------|--------|
| `pnpm typecheck` | PASS (only pre-existing localhost warning) |
| `pnpm test` | PASS — 223 passed, 8 skipped, 0 failures |
| `pnpm lint` | PASS — 0 warnings, 0 errors |

## Manual review

1. **Correctness** — All 7 plan tasks implemented as described: gtag config with Consent Mode v2 defaults, .env.example, Terraform prod+staging, and 3 custom events (blog_post_read, chat_started, code_runner_execute).
2. **Imports** — `useGtag` and `onMounted` are auto-imported by nuxt-gtag and Nuxt. No missing imports.
3. **Type errors** — None. `process.env.NUXT_PUBLIC_GTAG_ID` is `string | undefined`; the `enabled` flag gates usage.
4. **Unused code** — None.
5. **Pattern consistency** — Follows existing module config pattern in nuxt.config.ts, existing Terraform `additional_env_vars` pattern, and idiomatic `useGtag()` composable usage.
6. **Security** — Event parameters come from controlled sources (route params, computed values). No injection risks.
7. **Edge cases** — `post.value?.title` uses optional chaining. `enabled: false` when env var unset prevents script injection. `useGtag()` is SSR-safe (no-op on server).
8. **Incomplete work** — None. No TODOs or placeholders.
9. **Test coverage** — No new tests needed per plan — pure config + 3 thin analytics calls. Existing 223 tests unaffected.

## Code-simplify

Ran code-simplifier on all changed files. No simplifications recommended. The `useGtag()` pattern (called at point-of-use rather than hoisted) is a defensible choice that co-locates analytics with the event.

## Commit history

6 clean commits, each scoped to a single concern:
1. `feat(analytics): configure nuxt-gtag with Consent Mode v2 defaults`
2. `feat(analytics): document NUXT_PUBLIC_GTAG_ID in .env.example`
3. `feat(analytics): add NUXT_PUBLIC_GTAG_ID to Terraform environments`
4. `feat(analytic

---
Generated by auto-claude pipeline