### PR TITLE
fix(analytics): remove build-time enabled check that disables gtag

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -27,7 +27,6 @@ Both properties live under the **Chris Towles** GA account (19124393).
 
 ```ts
 gtag: {
-  enabled: !!process.env.NUXT_PUBLIC_GTAG_ID,
   id: process.env.NUXT_PUBLIC_GTAG_ID,
   initCommands: [
     ['consent', 'default', {
@@ -40,7 +39,7 @@ gtag: {
 },
 ```
 
-Analytics is **disabled** when `NUXT_PUBLIC_GTAG_ID` is unset. Consent Mode v2 defaults all consent categories to `denied` — no cookies until the user opts in.
+The module is always enabled (default `true`) so it registers its runtime config and plugin at build time. The actual gtag script only loads when `NUXT_PUBLIC_GTAG_ID` is set at runtime — this is critical because Docker builds don't have the env var (Cloud Run injects it). Consent Mode v2 defaults all consent categories to `denied` — no cookies until the user opts in.
 
 ### Per-environment wiring
 

--- a/packages/blog/nuxt.config.ts
+++ b/packages/blog/nuxt.config.ts
@@ -24,7 +24,6 @@ export default defineNuxtConfig({
   ],
 
   gtag: {
-    enabled: !!process.env.NUXT_PUBLIC_GTAG_ID,
     id: process.env.NUXT_PUBLIC_GTAG_ID,
     initCommands: [
       [


### PR DESCRIPTION
## Summary

- `enabled: !!process.env.NUXT_PUBLIC_GTAG_ID` was evaluated at **build time** in the Docker container, where the env var doesn't exist — causing nuxt-gtag to register mock composables and skip plugin/runtimeConfig registration entirely
- Remove the `enabled` line (default is `true`) so the module always registers at build time, and the actual gtag script loads only when `NUXT_PUBLIC_GTAG_ID` is set at runtime by Cloud Run
- Update docs/analytics.md to explain the build-time vs runtime distinction

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (223 tests)
- [ ] After deploy, verify `chris.towles.dev` includes gtag script in page source

🤖 Generated with [Claude Code](https://claude.com/claude-code)