### PR TITLE
fix(analytics): pass gtag ID at Docker build time for prerendered pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,7 @@ jobs:
           build-args: |
             GIT_SHA=${{ steps.tags.outputs.sha_tag }}
             BUILD_TAG=${{ steps.tags.outputs.date_tag }}
+            NUXT_PUBLIC_GTAG_ID=G-PH525YF11W
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -39,17 +39,22 @@ gtag: {
 },
 ```
 
-The module is always enabled (default `true`) so it registers its runtime config and plugin at build time. The actual gtag script only loads when `NUXT_PUBLIC_GTAG_ID` is set at runtime — this is critical because Docker builds don't have the env var (Cloud Run injects it). Consent Mode v2 defaults all consent categories to `denied` — no cookies until the user opts in.
+The module is always enabled (default `true`) so it registers its runtime config and plugin at build time. Consent Mode v2 defaults all consent categories to `denied` — no cookies until the user opts in.
+
+**Important:** `NUXT_PUBLIC_GTAG_ID` must be set at **build time** (not just runtime) because Nuxt prerenderers bake runtime config into static HTML. The Dockerfile accepts it as a build arg, and both CI/CD and the deploy script pass it automatically.
 
 ### Per-environment wiring
 
-| Environment | Where the ID is set                                        |
-| ----------- | ---------------------------------------------------------- |
-| Local       | `.env` → `NUXT_PUBLIC_GTAG_ID=G-57YWQXB9F0`                |
-| Staging     | Terraform `staging.tfvars` → `gtag_id` → Cloud Run env var |
-| Production  | Terraform `prod.tfvars` → `gtag_id` → Cloud Run env var    |
+| Environment | Where the ID is set                                                    |
+| ----------- | ---------------------------------------------------------------------- |
+| Local       | `.env` → `NUXT_PUBLIC_GTAG_ID=G-57YWQXB9F0`                          |
+| Staging     | `staging.tfvars` → build script reads `gtag_id` → Docker `--build-arg` |
+| Production  | `prod.tfvars` → CI/CD passes `--build-arg`, Terraform sets Cloud Run env |
 
-Terraform passes the ID via `additional_env_vars` in the Cloud Run module:
+The ID flows through two paths:
+
+1. **Build time** — Docker `ARG NUXT_PUBLIC_GTAG_ID` so prerendered pages include the gtag script
+2. **Runtime** — Terraform `additional_env_vars` on Cloud Run for SSR pages
 
 ```hcl
 # infra/terraform/environments/main.tf

--- a/infra/container/blog.Dockerfile
+++ b/infra/container/blog.Dockerfile
@@ -34,6 +34,10 @@ WORKDIR /app/packages/blog
 ENV NUXT_CONTENT_DATABASE=false
 ENV NITRO_PRESET=node-server
 
+# Google Analytics measurement ID — needed at build time for prerendered pages
+ARG NUXT_PUBLIC_GTAG_ID=""
+ENV NUXT_PUBLIC_GTAG_ID=$NUXT_PUBLIC_GTAG_ID
+
 # Build the Nuxt application
 ENV NODE_OPTIONS="--max-old-space-size=8192"
 RUN cd /app && pnpm --filter @chris-towles/blog exec nuxt build

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -190,12 +190,18 @@ async function deployContainer() {
   // Step 3: Get git SHA
   const gitSha = (await $`git rev-parse --short HEAD`.quiet()).stdout.trim();
 
+  // Step 3b: Read gtag_id from tfvars for prerendered pages
+  const tfvarsContent = fs.readFileSync(`${terraformDir}/${environment}.tfvars`, 'utf-8');
+  const gtagMatch = tfvarsContent.match(/gtag_id\s*=\s*"([^"]*)"/);
+  const gtagId = gtagMatch?.[1] || '';
+
   // Step 4: Build the image with both date tag and latest
   const imageWithDateTag = `${registry}/blog:${dateTag}`;
   const imageWithLatest = `${registry}/blog:latest`;
   console.log(chalk.yellow(`\n🔨 Building Docker image: ${imageWithDateTag}`));
   console.log(chalk.gray(`   Git SHA: ${gitSha}`));
-  await $`docker build -f infra/container/blog.Dockerfile --build-arg GIT_SHA=${gitSha} --build-arg BUILD_TAG=${dateTag} -t ${imageWithDateTag} -t ${imageWithLatest} .`;
+  if (gtagId) console.log(chalk.gray(`   Gtag ID: ${gtagId}`));
+  await $`docker build -f infra/container/blog.Dockerfile --build-arg GIT_SHA=${gitSha} --build-arg BUILD_TAG=${dateTag} --build-arg NUXT_PUBLIC_GTAG_ID=${gtagId} -t ${imageWithDateTag} -t ${imageWithLatest} .`;
 
   // Step 5: Push both tags
   console.log(chalk.yellow(`\n📤 Pushing images to registry...`));


### PR DESCRIPTION
## Summary

- Prerendered pages bake Nuxt runtime config into static HTML at build time — `NUXT_PUBLIC_GTAG_ID` was empty during Docker builds, so gtag never loaded on any page
- Add `NUXT_PUBLIC_GTAG_ID` as a Dockerfile `ARG` so the Nuxt build has the measurement ID for prerendering
- CI/CD workflow passes the prod measurement ID (`G-PH525YF11W`) as a build arg
- Deploy script reads `gtag_id` from the environment's `.tfvars` file and passes it as a build arg
- Update analytics docs to explain the build-time vs runtime dual-path wiring

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (223 tests)
- [ ] After deploy, verify `chris.towles.dev` page source includes gtag script with `G-PH525YF11W`

🤖 Generated with [Claude Code](https://claude.com/claude-code)