### PR TITLE
fix(analytics): pass gtag ID at build time + derive deploy config from tfvars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,10 +14,7 @@ permissions:
   id-token: write
 
 env:
-  GCP_PROJECT: blog-towles-production
-  GCP_REGION: us-central1
   CLOUD_RUN_SERVICE: blog
-  IMAGE_BASE: us-central1-docker.pkg.dev/blog-towles-production/containers/blog
 
 jobs:
   test:
@@ -31,6 +28,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Parse prod.tfvars
+        id: tfvars
+        run: |
+          TFVARS="infra/terraform/environments/prod.tfvars"
+          get() { grep "^$1" "$TFVARS" | sed 's/.*= *"\(.*\)"/\1/'; }
+          CONTAINER_IMAGE=$(get container_image)
+          echo "project_id=$(get project_id)" >> "$GITHUB_OUTPUT"
+          echo "site_url=$(get site_url)" >> "$GITHUB_OUTPUT"
+          echo "gtag_id=$(get gtag_id)" >> "$GITHUB_OUTPUT"
+          echo "region=$(echo "$CONTAINER_IMAGE" | sed 's/-docker\.pkg\.dev.*//')" >> "$GITHUB_OUTPUT"
+          echo "image_base=$(echo "$CONTAINER_IMAGE" | sed 's/:[^/]*$//')" >> "$GITHUB_OUTPUT"
+
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
         with:
@@ -41,7 +50,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Authenticate Docker to Artifact Registry
-        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+        run: gcloud auth configure-docker ${{ steps.tfvars.outputs.region }}-docker.pkg.dev --quiet
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -61,27 +70,27 @@ jobs:
           file: infra/container/blog.Dockerfile
           push: true
           tags: |
-            ${{ env.IMAGE_BASE }}:${{ steps.tags.outputs.date_tag }}
-            ${{ env.IMAGE_BASE }}:${{ steps.tags.outputs.sha_tag }}
-            ${{ env.IMAGE_BASE }}:latest
+            ${{ steps.tfvars.outputs.image_base }}:${{ steps.tags.outputs.date_tag }}
+            ${{ steps.tfvars.outputs.image_base }}:${{ steps.tags.outputs.sha_tag }}
+            ${{ steps.tfvars.outputs.image_base }}:latest
           build-args: |
             GIT_SHA=${{ steps.tags.outputs.sha_tag }}
             BUILD_TAG=${{ steps.tags.outputs.date_tag }}
-            NUXT_PUBLIC_GTAG_ID=G-PH525YF11W
+            NUXT_PUBLIC_GTAG_ID=${{ steps.tfvars.outputs.gtag_id }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Deploy to Cloud Run
         run: |
           gcloud run services update ${{ env.CLOUD_RUN_SERVICE }} \
-            --image=${{ env.IMAGE_BASE }}:${{ steps.tags.outputs.date_tag }} \
-            --region=${{ env.GCP_REGION }} \
-            --project=${{ env.GCP_PROJECT }}
+            --image=${{ steps.tfvars.outputs.image_base }}:${{ steps.tags.outputs.date_tag }} \
+            --region=${{ steps.tfvars.outputs.region }} \
+            --project=${{ steps.tfvars.outputs.project_id }}
 
       - name: Health check
         run: |
           sleep 10
-          STATUS=$(curl -s -o /dev/null -w '%{http_code}' https://chris.towles.dev)
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' ${{ steps.tfvars.outputs.site_url }})
           echo "Health check status: ${STATUS}"
           if [ "$STATUS" -ne 200 ]; then
             echo "::warning::Health check returned ${STATUS}, expected 200"

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -45,10 +45,10 @@ The module is always enabled (default `true`) so it registers its runtime config
 
 ### Per-environment wiring
 
-| Environment | Where the ID is set                                                    |
-| ----------- | ---------------------------------------------------------------------- |
-| Local       | `.env` → `NUXT_PUBLIC_GTAG_ID=G-57YWQXB9F0`                          |
-| Staging     | `staging.tfvars` → build script reads `gtag_id` → Docker `--build-arg` |
+| Environment | Where the ID is set                                                      |
+| ----------- | ------------------------------------------------------------------------ |
+| Local       | `.env` → `NUXT_PUBLIC_GTAG_ID=G-57YWQXB9F0`                              |
+| Staging     | `staging.tfvars` → build script reads `gtag_id` → Docker `--build-arg`   |
 | Production  | `prod.tfvars` → CI/CD passes `--build-arg`, Terraform sets Cloud Run env |
 
 The ID flows through two paths:


### PR DESCRIPTION
## Summary
- Pass `NUXT_PUBLIC_GTAG_ID` as a Docker build-arg so gtag is baked in at build time (fixes it being empty in Cloud Run)
- Remove hardcoded values from `deploy.yml` — CI now parses `prod.tfvars` dynamically, matching how `scripts/build.ts` already works locally
- Update analytics docs to reflect the build-time approach

## Test plan
- [ ] CI test job passes (lint, typecheck, unit tests)
- [ ] Deploy job parses tfvars correctly (check workflow logs for step outputs)
- [ ] Container builds with correct `NUXT_PUBLIC_GTAG_ID` build-arg
- [ ] Health check hits the correct URL from tfvars
- [ ] After merge: verify gtag fires on production site

🤖 Generated with [Claude Code](https://claude.com/claude-code)