### PR TITLE
fix(chat): remove unsupported instructions field from skills API params

### DIFF
--- a/packages/blog/server/utils/ai/skills-loader.ts
+++ b/packages/blog/server/utils/ai/skills-loader.ts
@@ -49,29 +49,22 @@ export function loadCustomSkills(): CustomSkill[] {
 
 /**
  * Format loaded skills as container skills config for the Anthropic API.
- * Returns pre-built Anthropic skills + custom skills from SKILL.md files.
+ * Returns pre-built Anthropic skills only. Custom skills from SKILL.md files
+ * are included in the system prompt via getSkillsSystemPrompt() instead,
+ * since the Skills API requires custom skills to be uploaded and referenced
+ * by generated skill_id — inline instructions are not supported.
  */
 export function getSkillsForAPI(): Array<{
   type: string;
   skill_id: string;
   version?: string;
-  instructions?: string;
 }> {
-  // Pre-built Anthropic document generation skills
-  const prebuiltSkills = [
+  return [
     { type: 'anthropic', skill_id: 'pdf', version: 'latest' },
     { type: 'anthropic', skill_id: 'pptx', version: 'latest' },
     { type: 'anthropic', skill_id: 'xlsx', version: 'latest' },
     { type: 'anthropic', skill_id: 'docx', version: 'latest' },
   ];
-
-  const customSkills = loadCustomSkills().map((skill) => ({
-    type: 'custom' as const,
-    skill_id: skill.name,
-    instructions: skill.body,
-  }));
-
-  return [...prebuiltSkills, ...customSkills];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes 400 error when starting a chat: `container.ContainerParams.skills.4.instructions: Extra inputs are not permitted`
- The Anthropic Skills API does not support inline `instructions` on custom skills — they must be uploaded via the Skills API and referenced by generated `skill_id`
- Removed custom skills from the container `skills` array; custom skill metadata was already in the system prompt via `getSkillsSystemPrompt()`

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 223 tests pass
- [x] Verified chat starts successfully on localhost with no SSE errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)