### PR TITLE
fix: PostgreSQL full-text search extensions (#160)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - '${DB_PORT}:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./infra/container/init-extensions.sql:/docker-entrypoint-initdb.d/init-extensions.sql
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U postgres']
       interval: 10s

--- a/infra/container/init-extensions.sql
+++ b/infra/container/init-extensions.sql
@@ -1,0 +1,5 @@
+-- PostgreSQL extensions required by the blog application
+-- This script runs automatically on first database creation via Docker Compose
+
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;

--- a/packages/blog/server/database/migrations/0002_fix_search_vector_tsvector.sql
+++ b/packages/blog/server/database/migrations/0002_fix_search_vector_tsvector.sql
@@ -1,3 +1,6 @@
+-- Enable pg_trgm extension for trigram similarity search
+CREATE EXTENSION IF NOT EXISTS pg_trgm;--> statement-breakpoint
+
 -- Convert searchVector from text to tsvector type
 ALTER TABLE "document_chunks" ALTER COLUMN "searchVector" TYPE tsvector USING to_tsvector('english', COALESCE("searchVector", ''));--> statement-breakpoint
 

--- a/packages/blog/server/database/migrations/meta/_journal.json
+++ b/packages/blog/server/database/migrations/meta/_journal.json
@@ -19,7 +19,7 @@
     {
       "idx": 2,
       "version": "7",
-      "when": 1739721600000,
+      "when": 1771633763000,
       "tag": "0002_fix_search_vector_tsvector",
       "breakpoints": true
     },


### PR DESCRIPTION
## Summary
- Fixed `searchVector` column type from `text` to `tsvector` in migration 0002
- Fixed out-of-order migration timestamp in Drizzle journal
- Added `pg_trgm` extension to migration
- Added Docker init script for `vector` and `pg_trgm` extensions on fresh DB setup

Closes #160

## Test plan
- [x] `pnpm test` — 223 passed
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)