### PR TITLE
content: blog post on Vercel/Nuxt AI documentation theory (#51)

### DIFF
--- a/packages/blog/content/2.blog/20260307.vercel-nuxt-ai-documentation-theory.md
+++ b/packages/blog/content/2.blog/20260307.vercel-nuxt-ai-documentation-theory.md
@@ -1,0 +1,63 @@
+---
+title: 'My Theory: Vercel Got the Nuxt Team for an AI-Powered Documentation Framework'
+description: "Vercel acquired NuxtLabs last July. The official story is about supporting open source. But I think there's a bigger play here — and it involves AI-powered documentation."
+date: '2026-03-07'
+badge:
+  label: 'AI'
+image:
+  src: '/images/blog/20260307-vercel-nuxt-ai-documentation-theory.png'
+  alt: 'Vercel and Nuxt logos connected by glowing AI neural network lines'
+authors:
+  - name: Chris Towles
+    to: https://twitter.com/Chris_Towles
+    avatar:
+      src: /images/ctowles-profile-512x512.png
+---
+
+I [posted a theory on X](https://x.com/Chris_Towles/status/1956789271634829454) that I want to expand on here.
+
+When [Vercel acquired NuxtLabs](https://vercel.com/blog/nuxtlabs-joins-vercel) last July, the narrative was straightforward: give the Nuxt core team financial stability, keep everything open source, and bring Vue developers into the Vercel ecosystem. Sebastien Chopin, Pooya Parsa, Daniel Roe, Anthony Fu — all brilliant engineers who now have steady salaries instead of chasing sponsorships.
+
+That's a good story. I believe it's true. But I don't think it's the _whole_ story.
+
+## The Pieces That Don't Quite Fit
+
+Here's what's been nagging at me. Vercel is a Next.js company. They've built their entire platform around React. Acquiring a Vue-based framework team is... unusual. Yes, Vercel already supported Nuxt deployment, and yes, Nitro (the server engine Pooya built) is framework-agnostic and genuinely useful to them. But four core hires plus the entire NuxtLabs team? That's not a "let's support the Vue ecosystem" move. That's an investment in specific people with specific skills.
+
+Now look at what those people actually built:
+
+- **Nuxt Content** — a file-based content layer that turns Markdown into a queryable, structured data source
+- **Nuxt Studio** — a visual editing experience for content-driven sites
+- **Nuxt Hub** — deployment and data infrastructure
+- **UnJS ecosystem** — Pooya's collection of universal JavaScript utilities that power everything from file routing to server engines
+
+Every single one of these is a content infrastructure tool. And content infrastructure is exactly what you need to build an AI-powered documentation system.
+
+## The AI Docs Play
+
+Think about what Vercel has been doing in 2026. They declared it the ["year of agents."](https://vercel.com/blog/introducing-the-new-v0) v0 is evolving from a code generator into a full application building agent. The AI SDK keeps expanding. They're experimenting with [inline LLM instructions in HTML](https://x.com/vercel/status/1958223471332519978). They even built a system that [scored 100% on Next.js evals](https://x.com/vercel/status/2016618115879358816) for keeping AI agents in sync with framework versions.
+
+Now imagine you're Vercel and you want to build the definitive AI-powered documentation platform — one where docs aren't just static pages but a living knowledge base that AI agents can query, reason about, and use to generate accurate, version-aware code. You'd need:
+
+1. A content layer that can parse, chunk, and structure Markdown at scale
+2. A visual editing experience so non-engineers can maintain docs
+3. A server engine flexible enough to serve both humans and AI agents
+4. People who deeply understand how developer documentation _works_
+
+The NuxtLabs team built all of that already. They just built it for a different purpose.
+
+## Why This Matters
+
+I use Nuxt for this blog. I've also used Vercel's platform extensively. What I've noticed is that the best developer tools right now are the ones that treat documentation as structured data rather than flat files. RAG systems need clean, chunked, well-organized content to work. The [Nuxt Content module](https://content.nuxt.com/) already does this — it parses Markdown, extracts frontmatter, builds a queryable content layer, and supports MDC (Markdown Components) for rich interactive docs.
+
+That's not just a documentation framework. That's the foundation for an AI-native documentation system.
+
+## I Could Be Wrong
+
+This is speculation. I have zero insider knowledge. The simplest explanation — Vercel wanted Nitro's universal server engine and hired great engineers — might be the complete truth.
+
+But when I look at where AI development tooling is heading, and I look at exactly what skills and tools the NuxtLabs team brings to the table, the pieces fit together too neatly for me to ignore.
+
+If I'm right, we'll see Vercel announce some kind of AI-powered documentation product in the next 6-12 months that looks suspiciously like Nuxt Content's architecture with an AI layer on top.
+
+I'll revisit this post when we find out.


### PR DESCRIPTION
## Summary
Opinion piece theorizing about Vercel's acquisition of NuxtLabs and the potential for an AI-powered documentation platform. ~650 words with falsifiable prediction.

Closes #51

## Test plan
- [x] Frontmatter format matches existing posts
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)