### PR TITLE
feat(reading): reading app enhancements — wizard, curriculum, phonics slider

### DIFF
--- a/docs/superpowers/specs/2026-03-19-spelling-words-design.md
+++ b/docs/superpowers/specs/2026-03-19-spelling-words-design.md
@@ -1,0 +1,136 @@
+# Spelling Words Feature Design
+
+Weekly spelling word decks with AI-generated images and two practice modes, integrated into the existing SRS system.
+
+## Problem
+
+Logan gets a weekly spelling word list from school. We need a way to enter these words, practice them with visual aids, and track progress using the existing spaced repetition system.
+
+## Data Model
+
+### New table: `spelling_decks`
+
+| Column    | Type      | Notes                          |
+|-----------|-----------|--------------------------------|
+| id        | serial PK |                                |
+| childId   | int FK    | → childProfiles                |
+| name      | text      | e.g. "Week 12 - March 19"     |
+| createdAt | timestamp |                                |
+
+### Changes to `srsCards`
+
+| Column   | Type     | Notes                                          |
+|----------|----------|-------------------------------------------------|
+| deckId   | int FK?  | → spelling_decks, nullable. Null for non-spelling cards. `onDelete: cascade` — deleting a deck removes its cards and SRS history. |
+| imageUrl | text?    | GCS URL for AI-generated image. Null for abstract words |
+
+Spelling cards use `cardType: 'spelling'`, `front: word`, `back: auto-generated definition`.
+
+Update `childProfilesRelations` to include `many(spellingDecks)` and `srsCardsRelations` to include `one(spellingDecks)`.
+
+## Word Entry
+
+### Input flow
+
+1. User navigates to `/reading/spelling/new`
+2. Enters deck name (default: "Week N - {date}")
+3. Enters words via text area — one per line, comma-separated, or free-typed
+4. Submit creates deck + SRS cards immediately
+5. Image generation runs in background — cards are usable in text-only mode while images generate
+
+### Concrete vs abstract classification
+
+Simple heuristic: check words against a list of common abstract words (prepositions, conjunctions, abstract concepts). Words not in the list are treated as concrete and get AI-generated images.
+
+### Definition generation
+
+Single Claude Haiku batch call with all words in the deck: "Give a simple, kid-friendly one-sentence definition for each word: {words}". Returns JSON mapping word → definition. Cheaper and faster than one call per word.
+
+## Practice Modes
+
+### Image-to-Spell (harder)
+
+- Show AI-generated image (or definition for abstract words)
+- Kid types the word
+- Check spelling on submit
+- Correct first try → Good (4), correct second try → Hard (3), wrong → Again (1)
+
+### Word-to-Image (easier)
+
+- Show the word
+- Display 4 images: 1 correct + 3 distractors from the same deck
+- Kid taps the matching image
+- Same SRS rating mapping
+- Abstract words without images are skipped in this mode
+- **Minimum threshold:** Requires at least 4 concrete words with images in the deck. If fewer, this mode is disabled with a message ("Need more picture words to play this game").
+
+### Entry points
+
+- "Practice this deck" on deck detail page — filters to that deck's due cards
+- Existing "review all" queue — spelling cards appear alongside other card types using image-to-spell mode
+- URL state: `/reading/practice?deckId=X&mode=image-to-spell` or `&mode=word-to-image`
+
+## Image Generation
+
+### Pipeline
+
+1. On deck creation, classify each word as concrete or abstract
+2. Generate one image per concrete word via Gemini (`gemini-2.5-flash-image`)
+3. 1:1 aspect ratio, same flat vector illustration style as story images
+4. Upload to GCS at `reading/spelling/{deckId}/{word}.png`
+5. Update card's `imageUrl` as each image completes
+
+### Prompt template
+
+```
+{ILLUSTRATION_STYLE} A single clear illustration of the concept "{word}".
+Simple, centered, no text or letters in the image.
+```
+
+### Async behavior
+
+Deck creation API creates cards and generates definitions synchronously (fast Haiku call). Image generation is fire-and-forget — the endpoint calls `generateSpellingImages(deckId, words)` without awaiting, then returns. Cards are immediately usable in text-only mode. Deck detail page polls/refetches to pick up images as they complete.
+
+Reuse `ILLUSTRATION_STYLE` from `server/utils/reading/image-generator.ts`. Add a new exported `generateSpellingImage(word)` function to that module.
+
+### Error handling
+
+Failed image generations leave `imageUrl` as null — card stays in text-only mode permanently. Deck detail page shows a "Retry" button for cards with missing images. One automatic retry per image on first failure.
+
+## API Routes
+
+### New
+
+| Method | Path                              | Purpose                                    |
+|--------|-----------------------------------|--------------------------------------------|
+| GET    | /api/reading/spelling/decks       | List decks for child                       |
+| POST   | /api/reading/spelling/decks       | Create deck (name + word list), trigger image gen |
+| GET    | /api/reading/spelling/decks/[id]  | Deck detail with cards                     |
+| DELETE | /api/reading/spelling/decks/[id]  | Remove deck and its cards                  |
+
+### Modified
+
+| Route                    | Change                                      |
+|--------------------------|---------------------------------------------|
+| GET /api/reading/srs/due | Add optional `deckId` query param to filter  |
+
+### Unchanged
+
+`POST /api/reading/srs/review` — works as-is for spelling cards.
+
+## Pages
+
+| Path                        | Purpose                          |
+|-----------------------------|----------------------------------|
+| /reading/spelling           | List all decks with progress     |
+| /reading/spelling/new       | Create new deck with word entry  |
+| /reading/spelling/[deckId]  | Deck detail, words, images, practice button |
+
+Practice happens on the existing `/reading/practice` page with `deckId` and `mode` query params.
+
+## Out of Scope
+
+- OCR / photo word entry (future feature)
+- Custom image upload
+- Sharing decks between children
+- Teacher/school integration

--- a/packages/blog/app/pages/reading/child/[id]/new.vue
+++ b/packages/blog/app/pages/reading/child/[id]/new.vue
@@ -8,15 +8,10 @@ const route = useRoute();
 const router = useRouter();
 const childId = computed(() => Number(route.params.id));
 
-const initialStep = (['input', 'previews', 'generating'] as const).includes(
-  route.query.step as 'input' | 'previews' | 'generating',
-)
-  ? (route.query.step as 'input' | 'previews' | 'generating')
-  : 'input';
 const genre = ref('');
 const who = ref('');
 const idea = ref('');
-const step = ref<'input' | 'previews' | 'generating'>(initialStep);
+const step = ref<'input' | 'previews' | 'generating'>('input');
 
 watch(step, (val) => {
   router.replace({ query: { ...route.query, step: val === 'input' ? undefined : val } });
@@ -48,6 +43,7 @@ const loadingMessageIndex = ref(0);
 let loadingInterval: ReturnType<typeof setInterval> | null = null;
 
 function startLoadingMessages() {
+  stopLoadingMessages();
   loadingMessageIndex.value = 0;
   loadingInterval = setInterval(() => {
     loadingMessageIndex.value = (loadingMessageIndex.value + 1) % LOADING_MESSAGES.length;

--- a/packages/blog/app/pages/reading/curriculum.vue
+++ b/packages/blog/app/pages/reading/curriculum.vue
@@ -78,16 +78,17 @@ function statusBadgeFor(
   return { label: 'Locked', color: 'var(--reading-text)', emoji: '\u{1F512}' };
 }
 
-// Pre-compute status badges for all units to avoid repeated O(n) lookups in the template
+// Pre-compute status badges keyed by "phase:orderIndex" to avoid O(n) indexOf lookups in template
 const unitBadges = computed(() => {
-  const map = new Map<number, ReturnType<typeof statusBadgeFor>>();
+  const map = new Map<string, ReturnType<typeof statusBadgeFor>>();
   for (let i = 0; i < PHONICS_SEED.length; i++) {
+    const unit = PHONICS_SEED[i]!;
     let status: 'locked' | 'active' | 'mastered' | null = null;
     if (progress.value && activeChildId.value) {
       const p = progress.value.find((pr) => pr.phonicsUnitId === i + 1);
       status = p?.status ?? null;
     }
-    map.set(i, statusBadgeFor(status));
+    map.set(`${unit.phase}:${unit.orderIndex}`, statusBadgeFor(status));
   }
   return map;
 });
@@ -251,17 +252,17 @@ const sightWordsByPhase = SIGHT_WORDS_BY_PHASE;
                       {{ unit.name }}
                     </h3>
                     <!-- Progress badge if child selected -->
-                    <template v-if="activeChildId">
+                    <template v-if="activeChildId && unitBadges.get(`${phase}:${unit.orderIndex}`)">
                       <span
-                        v-if="unitBadges.get(PHONICS_SEED.indexOf(unit))"
                         class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-bold"
                         :style="{
-                          backgroundColor: unitBadges.get(PHONICS_SEED.indexOf(unit))!.color + '22',
-                          color: unitBadges.get(PHONICS_SEED.indexOf(unit))!.color,
+                          backgroundColor:
+                            unitBadges.get(`${phase}:${unit.orderIndex}`)!.color + '22',
+                          color: unitBadges.get(`${phase}:${unit.orderIndex}`)!.color,
                         }"
                       >
-                        {{ unitBadges.get(PHONICS_SEED.indexOf(unit))!.emoji }}
-                        {{ unitBadges.get(PHONICS_SEED.indexOf(unit))!.label }}
+                        {{ unitBadges.get(`${phase}:${unit.orderIndex}`)!.emoji }}
+                        {{ unitBadges.get(`${phase}:${unit.orderIndex}`)!.label }}
                       </span>
                     </template>
                   </div>

--- a/packages/blog/app/pages/reading/practice.vue
+++ b/packages/blog/app/pages/reading/practice.vue
@@ -31,13 +31,26 @@ watch(
 const elapsedSeconds = ref(0);
 let timer: ReturnType<typeof setInterval> | null = null;
 
-onMounted(() => {
-  timer = setInterval(() => {
-    if (sessionStartTime.value && !sessionComplete.value) {
-      elapsedSeconds.value = Math.floor((Date.now() - sessionStartTime.value) / 1000);
+const sessionActive = computed(() => !!sessionStartTime.value && !sessionComplete.value);
+
+watch(
+  sessionActive,
+  (active) => {
+    if (active) {
+      if (!timer) {
+        timer = setInterval(() => {
+          elapsedSeconds.value = Math.floor((Date.now() - sessionStartTime.value!) / 1000);
+        }, 1000);
+      }
+    } else {
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
     }
-  }, 1000);
-});
+  },
+  { immediate: true },
+);
 
 onUnmounted(() => {
   if (timer) clearInterval(timer);

--- a/packages/blog/server/utils/env-config.ts
+++ b/packages/blog/server/utils/env-config.ts
@@ -25,8 +25,8 @@ export const envSchema = z.object({
   // Google AI (Gemini) — optional, used for story illustrations
   GOOGLE_AI_API_KEY: z.string().optional().default(''),
 
-  // GCS media bucket for reading illustrations
-  GCS_BUCKET_NAME: z.string().min(1, 'GCS_BUCKET_NAME is required'),
+  // GCS media bucket for reading illustrations (optional — falls back to error at upload time)
+  GCS_BUCKET_NAME: z.string().optional().default(''),
 
   // AWS Bedrock
   AWS_REGION: z.string().default('us-east-1'),

--- a/packages/blog/server/utils/reading/image-generator.test.ts
+++ b/packages/blog/server/utils/reading/image-generator.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { extractCharacters, buildCharacterPrompt, CHARACTER_DESCRIPTIONS } from './image-generator';
+
+describe('extractCharacters', () => {
+  it('finds a single character', () => {
+    expect(extractCharacters('The cat sat on a mat.')).toContain('cat');
+  });
+
+  it('finds multiple characters', () => {
+    const chars = extractCharacters('The cat and the dog played.');
+    expect(chars).toContain('cat');
+    expect(chars).toContain('dog');
+  });
+
+  it('is case-insensitive', () => {
+    expect(extractCharacters('The Cat sat.')).toContain('cat');
+    expect(extractCharacters('A BIG DOG ran.')).toContain('dog');
+  });
+
+  it('returns empty array when no known characters found', () => {
+    expect(extractCharacters('The tree swayed in the wind.')).toEqual([]);
+  });
+
+  it('prefers longer key "red hen" over "hen" to avoid duplicates', () => {
+    const chars = extractCharacters('The red hen found some grain.');
+    expect(chars).toContain('red hen');
+    // Should not have duplicate descriptions
+    expect(chars).toHaveLength(1);
+  });
+
+  it('finds characters across multiple sentences', () => {
+    const chars = extractCharacters('The cat ran fast. Then the fish jumped. Dan smiled.');
+    expect(chars).toContain('cat');
+    expect(chars).toContain('fish');
+    expect(chars).toContain('dan');
+  });
+
+  it('handles empty string', () => {
+    expect(extractCharacters('')).toEqual([]);
+  });
+});
+
+describe('buildCharacterPrompt', () => {
+  it('returns empty string for no characters', () => {
+    expect(buildCharacterPrompt([])).toBe('');
+  });
+
+  it('returns empty string for unknown characters', () => {
+    expect(buildCharacterPrompt(['unicorn', 'dragon'])).toBe('');
+  });
+
+  it('builds prompt for known character', () => {
+    const result = buildCharacterPrompt(['cat']);
+    expect(result).toContain('Characters in the scene:');
+    expect(result).toContain(CHARACTER_DESCRIPTIONS['cat']);
+  });
+
+  it('builds prompt for multiple known characters', () => {
+    const result = buildCharacterPrompt(['cat', 'dog']);
+    expect(result).toContain(CHARACTER_DESCRIPTIONS['cat']);
+    expect(result).toContain(CHARACTER_DESCRIPTIONS['dog']);
+  });
+
+  it('filters out unknown characters and includes known ones', () => {
+    const result = buildCharacterPrompt(['cat', 'unicorn', 'fish']);
+    expect(result).toContain(CHARACTER_DESCRIPTIONS['cat']);
+    expect(result).toContain(CHARACTER_DESCRIPTIONS['fish']);
+    expect(result).not.toContain('unicorn');
+  });
+});

--- a/packages/blog/server/utils/reading/image-generator.ts
+++ b/packages/blog/server/utils/reading/image-generator.ts
@@ -36,11 +36,14 @@ export function buildCharacterPrompt(characters: string[]): string {
   return `Characters in the scene: ${descriptions.join(' ')}`;
 }
 
+const SORTED_CHARACTER_KEYS = Object.keys(CHARACTER_DESCRIPTIONS).sort(
+  (a, b) => b.length - a.length,
+);
+
 export function extractCharacters(text: string): string[] {
   const lowerText = text.toLowerCase();
   const found: string[] = [];
-  // Check longer keys first to avoid duplicate matches (e.g. "red hen" before "hen")
-  const keys = Object.keys(CHARACTER_DESCRIPTIONS).sort((a, b) => b.length - a.length);
+  const keys = SORTED_CHARACTER_KEYS;
   for (const key of keys) {
     if (
       lowerText.includes(key) &&
@@ -111,10 +114,14 @@ export async function generateStoryIllustrations(
   return { cover: cover!, pages };
 }
 
-const gcsStorage = new Storage();
+let gcsStorage: Storage | null = null;
+function getGcsStorage(): Storage {
+  if (!gcsStorage) gcsStorage = new Storage();
+  return gcsStorage;
+}
 
 async function uploadToGcs(bucket: string, path: string, buffer: Buffer): Promise<string> {
-  const file = gcsStorage.bucket(bucket).file(path);
+  const file = getGcsStorage().bucket(bucket).file(path);
   await file.save(buffer, {
     contentType: 'image/png',
     metadata: { cacheControl: 'public, max-age=31536000' },

--- a/packages/blog/server/utils/reading/image-generator.ts
+++ b/packages/blog/server/utils/reading/image-generator.ts
@@ -9,7 +9,7 @@ interface StoryIllustrations {
 const ILLUSTRATION_STYLE =
   'Flat vector illustration style. Soft rounded shapes with thick dark outlines. Warm saturated colors on cream/warm white backgrounds. Characters have simple expressive faces with dot eyes and small mouths. Characters are 2-3 heads tall (chibi proportions). Style similar to Bluey or Peppa Pig — simple, clean, appealing to ages 5-10. No text, no words, no letters in the image. Scene has simple background elements (grass, sky, simple furniture). Consistent warm lighting.';
 
-const CHARACTER_DESCRIPTIONS: Record<string, string> = {
+export const CHARACTER_DESCRIPTIONS: Record<string, string> = {
   cat: 'An orange tabby cat with big green eyes, round body, short stubby legs, pink nose, always smiling. Thick dark outline.',
   hen: 'A plump red hen with bright yellow beak, small flapping wings, wearing a tiny blue polka-dot bow on head. Round body.',
   'red hen':
@@ -28,7 +28,7 @@ function getGeminiClient(): GoogleGenAI | null {
   return new GoogleGenAI({ apiKey });
 }
 
-function buildCharacterPrompt(characters: string[]): string {
+export function buildCharacterPrompt(characters: string[]): string {
   const descriptions = characters
     .map((c) => CHARACTER_DESCRIPTIONS[c.toLowerCase()])
     .filter(Boolean);
@@ -36,7 +36,7 @@ function buildCharacterPrompt(characters: string[]): string {
   return `Characters in the scene: ${descriptions.join(' ')}`;
 }
 
-function extractCharacters(text: string): string[] {
+export function extractCharacters(text: string): string[] {
   const lowerText = text.toLowerCase();
   const found: string[] = [];
   // Check longer keys first to avoid duplicate matches (e.g. "red hen" before "hen")

--- a/packages/blog/server/utils/reading/phonics-seed.test.ts
+++ b/packages/blog/server/utils/reading/phonics-seed.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { PHONICS_SEED, SIGHT_WORDS_BY_PHASE } from './phonics-seed';
+import type { PhonicsPhase } from '~~/shared/reading-types';
+
+describe('PHONICS_SEED', () => {
+  it('contains units for all 4 phases', () => {
+    const phases = new Set(PHONICS_SEED.map((u) => u.phase));
+    expect(phases).toEqual(new Set([1, 2, 3, 4]));
+  });
+
+  it('has unique orderIndex within each phase', () => {
+    const byPhase = new Map<number, number[]>();
+    for (const unit of PHONICS_SEED) {
+      const indices = byPhase.get(unit.phase) ?? [];
+      indices.push(unit.orderIndex);
+      byPhase.set(unit.phase, indices);
+    }
+    for (const [phase, indices] of byPhase) {
+      const unique = new Set(indices);
+      expect(unique.size, `Phase ${phase} has duplicate orderIndex`).toBe(indices.length);
+    }
+  });
+
+  it('every unit has non-empty patterns array', () => {
+    for (const unit of PHONICS_SEED) {
+      expect(unit.patterns.length, `${unit.name} has empty patterns`).toBeGreaterThan(0);
+    }
+  });
+
+  it('every unit has a non-empty name and description', () => {
+    for (const unit of PHONICS_SEED) {
+      expect(unit.name.length).toBeGreaterThan(0);
+      expect(unit.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('has no duplicate pattern names across all units', () => {
+    const allPatterns = PHONICS_SEED.flatMap((u) => u.patterns);
+    const unique = new Set(allPatterns);
+    expect(unique.size).toBe(allPatterns.length);
+  });
+
+  it('orderIndex values are sequential starting from 1 within each phase', () => {
+    const byPhase = new Map<number, number[]>();
+    for (const unit of PHONICS_SEED) {
+      const indices = byPhase.get(unit.phase) ?? [];
+      indices.push(unit.orderIndex);
+      byPhase.set(unit.phase, indices);
+    }
+    for (const [phase, indices] of byPhase) {
+      const sorted = [...indices].sort((a, b) => a - b);
+      expect(sorted[0], `Phase ${phase} should start at 1`).toBe(1);
+      for (let i = 1; i < sorted.length; i++) {
+        expect(sorted[i], `Phase ${phase} gap at index ${i}`).toBe(sorted[i - 1]! + 1);
+      }
+    }
+  });
+});
+
+describe('SIGHT_WORDS_BY_PHASE', () => {
+  it('has entries for all 4 phases', () => {
+    const phases: PhonicsPhase[] = [1, 2, 3, 4];
+    for (const phase of phases) {
+      expect(SIGHT_WORDS_BY_PHASE[phase].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('all sight words are lowercase (except I)', () => {
+    for (const phase of [1, 2, 3, 4] as PhonicsPhase[]) {
+      for (const word of SIGHT_WORDS_BY_PHASE[phase]) {
+        if (word !== 'I') {
+          expect(word, `"${word}" in phase ${phase} should be lowercase`).toBe(word.toLowerCase());
+        }
+      }
+    }
+  });
+
+  it('has no duplicate sight words within a phase', () => {
+    for (const phase of [1, 2, 3, 4] as PhonicsPhase[]) {
+      const words = SIGHT_WORDS_BY_PHASE[phase];
+      const unique = new Set(words);
+      expect(unique.size, `Phase ${phase} has duplicate sight words`).toBe(words.length);
+    }
+  });
+});

--- a/packages/blog/server/utils/reading/phonics-validator.test.ts
+++ b/packages/blog/server/utils/reading/phonics-validator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateWord, calculateDecodability } from './phonics-validator';
+import { validateWord, calculateDecodability, annotateWords } from './phonics-validator';
 
 describe('phonics-validator', () => {
   const knownPatterns = ['CVC-short-a', 'CVC-short-i', 'DG-sh'];
@@ -12,13 +12,55 @@ describe('phonics-validator', () => {
       expect(result.pattern).toBe('CVC-short-a');
     });
 
+    it('recognizes CVC short-i words', () => {
+      const result = validateWord('sit', knownPatterns);
+      expect(result.decodable).toBe(true);
+      expect(result.pattern).toBe('CVC-short-i');
+    });
+
     it('recognizes sight words', () => {
       const result = validateWord('the', knownPatterns, sightWords);
       expect(result.sightWord).toBe(true);
+      expect(result.decodable).toBe(false);
     });
 
     it('rejects words with unknown patterns', () => {
       const result = validateWord('tree', knownPatterns);
+      expect(result.decodable).toBe(false);
+      expect(result.sightWord).toBe(false);
+    });
+
+    it('preserves original text in result', () => {
+      const result = validateWord('Cat!', knownPatterns);
+      expect(result.text).toBe('Cat!');
+      expect(result.decodable).toBe(true);
+    });
+
+    it('strips punctuation for matching', () => {
+      const result = validateWord('cat.', knownPatterns);
+      expect(result.decodable).toBe(true);
+      expect(result.pattern).toBe('CVC-short-a');
+    });
+
+    it('is case-insensitive', () => {
+      const result = validateWord('CAT', knownPatterns);
+      expect(result.decodable).toBe(true);
+    });
+
+    it('matches digraph pattern', () => {
+      const result = validateWord('ship', knownPatterns);
+      expect(result.decodable).toBe(true);
+      expect(result.pattern).toBe('DG-sh');
+    });
+
+    it('defaults sightWords to empty array', () => {
+      const result = validateWord('the', knownPatterns);
+      expect(result.sightWord).toBe(false);
+      expect(result.decodable).toBe(false);
+    });
+
+    it('handles empty string', () => {
+      const result = validateWord('', knownPatterns);
       expect(result.decodable).toBe(false);
     });
   });
@@ -34,6 +76,78 @@ describe('phonics-validator', () => {
       const words = ['cat', 'tree', 'the'];
       const score = calculateDecodability(words, knownPatterns, sightWords);
       expect(score).toBeCloseTo(0.67, 1);
+    });
+
+    it('returns 1.0 for empty word list', () => {
+      expect(calculateDecodability([], knownPatterns, sightWords)).toBe(1.0);
+    });
+
+    it('returns 0 when no words are decodable', () => {
+      const words = ['tree', 'blue', 'green'];
+      expect(calculateDecodability(words, knownPatterns, sightWords)).toBe(0);
+    });
+  });
+
+  describe('annotateWords', () => {
+    it('annotates a simple sentence', () => {
+      const result = annotateWords('the cat sat', knownPatterns, sightWords);
+      expect(result).toHaveLength(3);
+      expect(result[0]!.sightWord).toBe(true);
+      expect(result[0]!.text).toBe('the');
+      expect(result[1]!.decodable).toBe(true);
+      expect(result[1]!.text).toBe('cat');
+      expect(result[2]!.decodable).toBe(true);
+      expect(result[2]!.text).toBe('sat');
+    });
+
+    it('returns empty array for empty string', () => {
+      expect(annotateWords('', knownPatterns, sightWords)).toEqual([]);
+    });
+
+    it('handles multiple spaces between words', () => {
+      const result = annotateWords('cat   sat', knownPatterns, sightWords);
+      expect(result).toHaveLength(2);
+    });
+
+    it('marks unknown words correctly', () => {
+      const result = annotateWords('the tree is tall', knownPatterns, sightWords);
+      expect(result[1]!.decodable).toBe(false);
+      expect(result[1]!.sightWord).toBe(false);
+      expect(result[3]!.decodable).toBe(false);
+    });
+  });
+
+  describe('pattern coverage', () => {
+    it('validates VCe patterns', () => {
+      const patterns = ['VCe-a', 'VCe-i', 'VCe-o'];
+      expect(validateWord('cake', patterns).decodable).toBe(true);
+      expect(validateWord('ride', patterns).decodable).toBe(true);
+      expect(validateWord('bone', patterns).decodable).toBe(true);
+    });
+
+    it('validates vowel team patterns', () => {
+      const patterns = ['VT-ee', 'VT-ea', 'VT-ai', 'VT-ay', 'VT-oa'];
+      expect(validateWord('tree', patterns).decodable).toBe(true);
+      expect(validateWord('read', patterns).decodable).toBe(true);
+      expect(validateWord('rain', patterns).decodable).toBe(true);
+      expect(validateWord('play', patterns).decodable).toBe(true);
+      expect(validateWord('boat', patterns).decodable).toBe(true);
+    });
+
+    it('validates r-controlled patterns', () => {
+      const patterns = ['RC-ar', 'RC-or', 'RC-er', 'RC-ir', 'RC-ur'];
+      expect(validateWord('car', patterns).decodable).toBe(true);
+      expect(validateWord('for', patterns).decodable).toBe(true);
+      expect(validateWord('her', patterns).decodable).toBe(true);
+      expect(validateWord('bird', patterns).decodable).toBe(true);
+      expect(validateWord('burn', patterns).decodable).toBe(true);
+    });
+
+    it('validates digraph ck pattern', () => {
+      expect(validateWord('back', ['DG-ck']).decodable).toBe(true);
+      expect(validateWord('kick', ['DG-ck']).decodable).toBe(true);
+      // ck not at end should not match
+      expect(validateWord('ckab', ['DG-ck']).decodable).toBe(false);
     });
   });
 });

--- a/packages/blog/server/utils/reading/story-generator.test.ts
+++ b/packages/blog/server/utils/reading/story-generator.test.ts
@@ -1,28 +1,5 @@
 import { describe, it, expect } from 'vitest';
-
-// Unit tests for pure functions (no API key needed)
-// Export the pure functions for testing by importing the module
-// Note: generateStory requires ANTHROPIC_API_KEY and is tested in the integration test
-
-// Re-implement locally since they're not exported
-function countSyllables(word: string): number {
-  const clean = word.toLowerCase().replace(/[^a-z]/g, '');
-  if (clean.length <= 3) return 1;
-  const matches = clean.match(/[aeiouy]+/g);
-  let count = matches ? matches.length : 1;
-  if (clean.endsWith('e') && !clean.endsWith('le')) count--;
-  return Math.max(1, count);
-}
-
-function calculateFleschKincaid(text: string): number {
-  const sentences = text.split(/[.!?]+/).filter(Boolean);
-  const words = text.split(/\s+/).filter(Boolean);
-  const syllables = words.reduce((sum, w) => sum + countSyllables(w), 0);
-
-  if (sentences.length === 0 || words.length === 0) return 0;
-
-  return 0.39 * (words.length / sentences.length) + 11.8 * (syllables / words.length) - 15.59;
-}
+import { countSyllables, calculateFleschKincaid, buildStoryPromptExtras } from './story-generator';
 
 describe('countSyllables', () => {
   it('counts single syllable words', () => {
@@ -60,6 +37,11 @@ describe('countSyllables', () => {
     expect(countSyllables('cat!')).toBe(1);
     expect(countSyllables('dog.')).toBe(1);
   });
+
+  it('handles empty-ish input', () => {
+    expect(countSyllables('')).toBe(1);
+    expect(countSyllables('...')).toBe(1);
+  });
 });
 
 describe('calculateFleschKincaid', () => {
@@ -70,22 +52,58 @@ describe('calculateFleschKincaid', () => {
   it('calculates grade level for simple sentences', () => {
     const text = 'The cat sat. The dog ran. The big hat.';
     const score = calculateFleschKincaid(text);
-    // Simple CVC sentences should produce a low grade level
     expect(score).toBeLessThan(5);
   });
 
   it('produces higher scores for complex text', () => {
     const simple = 'The cat sat on a mat.';
     const complex = 'The extraordinary circumstances necessitated immediate intervention.';
-    const simpleScore = calculateFleschKincaid(simple);
-    const complexScore = calculateFleschKincaid(complex);
-    expect(complexScore).toBeGreaterThan(simpleScore);
+    expect(calculateFleschKincaid(complex)).toBeGreaterThan(calculateFleschKincaid(simple));
   });
 
   it('handles single sentence', () => {
-    const text = 'The cat is big.';
-    const score = calculateFleschKincaid(text);
+    const score = calculateFleschKincaid('The cat is big.');
     expect(typeof score).toBe('number');
     expect(Number.isFinite(score)).toBe(true);
+  });
+
+  it('handles text with only punctuation-separated fragments', () => {
+    const score = calculateFleschKincaid('Run! Jump! Go!');
+    expect(Number.isFinite(score)).toBe(true);
+  });
+});
+
+describe('buildStoryPromptExtras', () => {
+  it('returns empty string with no options', () => {
+    expect(buildStoryPromptExtras({})).toBe('');
+  });
+
+  it('includes character when who is set', () => {
+    const result = buildStoryPromptExtras({ who: 'Rex the dog' });
+    expect(result).toContain('MAIN CHARACTER: Rex the dog');
+  });
+
+  it('includes idea when set', () => {
+    const result = buildStoryPromptExtras({ idea: 'a trip to the park' });
+    expect(result).toContain('STORY IDEA: a trip to the park');
+  });
+
+  it('includes selected preview', () => {
+    const result = buildStoryPromptExtras({
+      selectedPreview: { title: 'Fun Day', summary: 'A fun day at the beach' },
+    });
+    expect(result).toContain('USE THIS STORY CONCEPT');
+    expect(result).toContain('Fun Day');
+    expect(result).toContain('A fun day at the beach');
+  });
+
+  it('combines all options with newlines', () => {
+    const result = buildStoryPromptExtras({
+      who: 'Cat',
+      idea: 'adventure',
+      selectedPreview: { title: 'T', summary: 'S' },
+    });
+    const lines = result.split('\n');
+    expect(lines).toHaveLength(3);
   });
 });

--- a/packages/blog/server/utils/reading/story-generator.ts
+++ b/packages/blog/server/utils/reading/story-generator.ts
@@ -30,7 +30,7 @@ interface GeneratedStory {
 
 const MAX_RETRIES = 2;
 
-function buildStoryPromptExtras(options: {
+export function buildStoryPromptExtras(options: {
   who?: string;
   idea?: string;
   selectedPreview?: StoryPreview;
@@ -163,7 +163,7 @@ Output as JSON: { "title": "...", "text": "..." }`,
   throw new Error('Failed to generate story with sufficient decodability');
 }
 
-function calculateFleschKincaid(text: string): number {
+export function calculateFleschKincaid(text: string): number {
   const sentences = text.split(/[.!?]+/).filter(Boolean);
   const words = text.split(/\s+/).filter(Boolean);
   const syllables = words.reduce((sum, w) => sum + countSyllables(w), 0);
@@ -173,7 +173,7 @@ function calculateFleschKincaid(text: string): number {
   return 0.39 * (words.length / sentences.length) + 11.8 * (syllables / words.length) - 15.59;
 }
 
-function countSyllables(word: string): number {
+export function countSyllables(word: string): number {
   const clean = word.toLowerCase().replace(/[^a-z]/g, '');
   if (clean.length <= 3) return 1;
   const matches = clean.match(/[aeiouy]+/g);

--- a/packages/blog/server/utils/reading/story-safety.test.ts
+++ b/packages/blog/server/utils/reading/story-safety.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { reviewStorySafety, BLOCKLIST } from './story-safety';
+
+// Mock the Anthropic client — only the AI stage, blocklist is pure logic
+vi.mock('../ai/anthropic', () => ({
+  getAnthropicClient: () => ({
+    messages: {
+      create: vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: '{ "safe": true, "reason": "Appropriate content" }' }],
+      }),
+    },
+  }),
+}));
+
+describe('reviewStorySafety', () => {
+  describe('blocklist scan', () => {
+    it('catches every blocklist word', async () => {
+      for (const word of BLOCKLIST) {
+        const result = await reviewStorySafety(`The ${word} appeared.`);
+        expect(result.safe, `"${word}" should be blocked`).toBe(false);
+        expect(result.reason).toContain(word);
+      }
+    });
+
+    it('is case-insensitive', async () => {
+      const result = await reviewStorySafety('The MONSTER appeared!');
+      expect(result.safe).toBe(false);
+      expect(result.reason).toContain('monster');
+    });
+
+    it('does not false-positive on words containing blocklist substrings', async () => {
+      // "father" contains "fat", "hello" contains "hell", "shell" contains "hell"
+      const safeStories = [
+        'Her father smiled warmly.',
+        'Hello there, good morning!',
+        'The shell was on the beach.',
+      ];
+      for (const story of safeStories) {
+        const result = await reviewStorySafety(story);
+        expect(result.safe, `"${story}" should be safe`).toBe(true);
+      }
+    });
+  });
+
+  describe('AI review (mocked)', () => {
+    it('returns safe for clean content when AI approves', async () => {
+      const result = await reviewStorySafety('The cat sat on the mat and smiled.');
+      expect(result.safe).toBe(true);
+    });
+  });
+});

--- a/packages/blog/server/utils/reading/story-safety.ts
+++ b/packages/blog/server/utils/reading/story-safety.ts
@@ -1,6 +1,6 @@
 import { getAnthropicClient } from '../ai/anthropic';
 
-const BLOCKLIST = [
+export const BLOCKLIST = [
   'kill',
   'murder',
   'blood',
@@ -36,9 +36,9 @@ interface SafetyResult {
 
 export async function reviewStorySafety(storyText: string): Promise<SafetyResult> {
   // Stage 1: Blocklist scan
-  const lowerText = storyText.toLowerCase();
   for (const word of BLOCKLIST) {
-    if (lowerText.includes(word)) {
+    const boundary = new RegExp(`\\b${word}\\b`, 'i');
+    if (boundary.test(storyText)) {
       return { safe: false, reason: `Contains blocked word: "${word}"` };
     }
   }


### PR DESCRIPTION
## Summary
- Story creation wizard with genre picker, character input, idea field, and preview selection
- Curriculum page showing all 4 phonics phases with progress badges
- Phonics sound-out slider component for word segmentation during reading
- Practice page with full session tracking (timer, stats, completion screen)
- GCS bucket for story illustrations (replaces local filesystem)
- About page explaining all reading app features
- URL state sync across all reading pages

## Test plan
- [x] All 291 unit tests pass
- [x] Lint and typecheck clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)