### PR TITLE
fix: grant analytics_storage consent so GA4 records sessions

### DIFF
--- a/packages/blog/nuxt.config.ts
+++ b/packages/blog/nuxt.config.ts
@@ -33,7 +33,7 @@ export default defineNuxtConfig({
           ad_user_data: 'denied',
           ad_personalization: 'denied',
           ad_storage: 'denied',
-          analytics_storage: 'denied',
+          analytics_storage: 'granted',
         },
       ],
     ],


### PR DESCRIPTION
## Summary
- `analytics_storage` was set to `denied` by default in Consent Mode v2 config
- No consent banner exists to ever update it to `granted`
- GA4 was silently dropping all session data — explaining zero traffic in reports
- Changed `analytics_storage` to `granted` since this is a personal blog with no ads

## Test plan
- [ ] Deploy to staging and verify gtag fires with `analytics_storage: granted` in Chrome DevTools
- [ ] Confirm GA4 Realtime report shows the visit

🤖 Generated with [Claude Code](https://claude.com/claude-code)