### PR TITLE
fix: remove debug console.log statements from chat and artifact code

### DIFF
--- a/packages/blog/app/composables/useArtifact.ts
+++ b/packages/blog/app/composables/useArtifact.ts
@@ -94,8 +94,8 @@ export function useArtifact(options: UseArtifactOptions = {}) {
           try {
             const event: ArtifactSSEEvent = JSON.parse(line.slice(6));
             processEvent(event);
-          } catch (e) {
-            console.error('Error parsing artifact SSE event:', e, line);
+          } catch {
+            // Ignore malformed SSE lines (partial chunks, keep-alive)
           }
         }
       }

--- a/packages/blog/app/composables/useChat.ts
+++ b/packages/blog/app/composables/useChat.ts
@@ -169,8 +169,8 @@ export function useChat(options: UseChatOptions) {
                 codeExecutions,
               );
             }
-          } catch (e) {
-            console.error('Error parsing SSE event:', e, line);
+          } catch {
+            // Ignore malformed SSE lines (partial chunks, keep-alive)
           }
         }
       }
@@ -181,7 +181,6 @@ export function useChat(options: UseChatOptions) {
         status.value = 'ready';
         return;
       }
-      console.error('Chat error:', err);
       error.value = err instanceof Error ? err : new Error('Unknown error');
       status.value = 'error';
       options.onError?.(error.value);

--- a/packages/blog/app/composables/useLoanChat.ts
+++ b/packages/blog/app/composables/useLoanChat.ts
@@ -85,7 +85,7 @@ export function useLoanChat(options: UseLoanChatOptions) {
             }
           } catch (e) {
             if (e instanceof Error && e.message.startsWith('HTTP')) throw e;
-            console.error('Error parsing SSE event:', e, line);
+            // Ignore malformed SSE lines (partial chunks, keep-alive)
           }
         }
       }

--- a/packages/blog/app/composables/useLoanReview.ts
+++ b/packages/blog/app/composables/useLoanReview.ts
@@ -72,8 +72,8 @@ export function useLoanReview(options: UseLoanReviewOptions) {
           try {
             const event: LoanReviewSSEEvent = JSON.parse(line.slice(6));
             handleEvent(event);
-          } catch (e) {
-            console.error('Error parsing review SSE:', e, line);
+          } catch {
+            // Ignore malformed SSE lines (partial chunks, keep-alive)
           }
         }
       }

--- a/packages/blog/app/pages/chat/[id].vue
+++ b/packages/blog/app/pages/chat/[id].vue
@@ -43,7 +43,6 @@ const chat = useChat({
   initialMessages,
   model,
   onError(error) {
-    console.error('Chat error:', error.message);
     toast.add({
       description: error.message,
       icon: 'i-lucide-alert-circle',

--- a/packages/blog/app/pages/chat/index.vue
+++ b/packages/blog/app/pages/chat/index.vue
@@ -27,15 +27,12 @@ async function createChat(prompt: string) {
       method: 'POST',
       body: { input: prompt },
     });
-    console.log('chat', chat);
     refreshNuxtData('chats');
     const { gtag } = useGtag();
     gtag('event', 'chat_started');
     await navigateTo(`/chat/${chat.id}`);
     // no loading state to reset, because we are navigating away.
   } catch (error) {
-    console.error('error', error);
-
     loading.value = false;
     toast.add({
       description: extractErrorMessage(error),


### PR DESCRIPTION
## Summary
- Removed debug `console.log('chat', chat)` and `console.error('error', error)` from chat pages that leaked development noise into the browser console
- Removed redundant `console.error` calls in client-side composables (`useChat`, `useArtifact`, `useLoanChat`, `useLoanReview`) where errors are already handled via callbacks, toast notifications, or error state
- Replaced noisy SSE parse error logging with silent catch blocks (partial chunks and keep-alive lines are expected)
- Server-side `console.warn` and `console.error` in API routes are intentionally preserved — they serve production observability (file metadata failures, stream errors, tool parse failures)

## Files changed
- `app/pages/chat/index.vue` — removed debug log and redundant error log
- `app/pages/chat/[id].vue` — removed debug error log (toast handles display)
- `app/composables/useChat.ts` — removed SSE parse noise and redundant error log
- `app/composables/useArtifact.ts` — removed SSE parse noise
- `app/composables/useLoanChat.ts` — removed SSE parse noise
- `app/composables/useLoanReview.ts` — removed SSE parse noise

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [ ] Chat functionality works (sending messages, SSE streaming)
- [ ] Artifact execution works (code runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)