### PR TITLE
fix: improve error handling in chat and stream API routes

### DIFF
--- a/packages/blog/server/api/chats/[id].post.ts
+++ b/packages/blog/server/api/chats/[id].post.ts
@@ -371,7 +371,15 @@ export default defineEventHandler(async (event) => {
                   args: toolArgs,
                 });
 
-                const toolResult = await executeTool(currentToolName, toolArgs, { baseUrl });
+                let toolResult: unknown;
+                try {
+                  toolResult = await executeTool(currentToolName, toolArgs, { baseUrl });
+                } catch (toolError) {
+                  console.error(`Tool "${currentToolName}" execution failed:`, toolError);
+                  const errorMsg =
+                    toolError instanceof Error ? toolError.message : 'Tool execution failed';
+                  toolResult = { error: errorMsg };
+                }
                 toolResults.push({
                   type: 'tool_result',
                   tool_use_id: currentToolUseId,

--- a/packages/blog/server/utils/ai/stream-adapter.ts
+++ b/packages/blog/server/utils/ai/stream-adapter.ts
@@ -31,12 +31,18 @@ export interface AgentAssistantMessage {
   };
 }
 
+export interface AgentToolResultPart {
+  type: 'tool_result';
+  tool_use_id: string;
+  content: string | unknown;
+}
+
 export interface AgentUserMessage {
   type: 'user';
   session_id: string;
   message: {
     role: 'user';
-    content: string | Array<{ type: 'text'; text: string }>;
+    content: string | Array<{ type: 'text'; text: string } | AgentToolResultPart>;
   };
 }
 
@@ -173,13 +179,14 @@ function processMessage(message: AgentMessage, state: StreamState): SSEEvent[] {
       // User messages with tool results - extract tool results
       if (Array.isArray(message.message.content)) {
         for (const part of message.message.content) {
-          const partObj = part as unknown as Record<string, unknown>;
-          if (partObj.type === 'tool_result' && typeof partObj.tool_use_id === 'string') {
-            const toolUseId = partObj.tool_use_id;
+          if (typeof part === 'object' && part.type === 'tool_result') {
+            const toolResult = part as AgentToolResultPart;
+            const toolUseId = toolResult.tool_use_id;
+            if (typeof toolUseId !== 'string') continue;
             const content =
-              typeof partObj.content === 'string'
-                ? partObj.content
-                : JSON.stringify(partObj.content);
+              typeof toolResult.content === 'string'
+                ? toolResult.content
+                : JSON.stringify(toolResult.content);
             // Parse the result if it's JSON
             let result: unknown;
             try {
@@ -226,8 +233,8 @@ function processMessage(message: AgentMessage, state: StreamState): SSEEvent[] {
             if (state.toolInputJson) {
               toolArgs = JSON.parse(state.toolInputJson);
             }
-          } catch {
-            // Invalid JSON, use empty args
+          } catch (e) {
+            console.warn('[stream-adapter] Failed to parse tool input JSON:', e);
           }
           events.push({
             type: 'tool_start',

--- a/packages/blog/server/utils/ai/tools.ts
+++ b/packages/blog/server/utils/ai/tools.ts
@@ -140,9 +140,15 @@ export async function executeTool(
       if (!query) {
         return { error: 'Query is required' };
       }
-      const results = await retrieveRAG(query, {
-        topK: 5,
-      });
+      let results;
+      try {
+        results = await retrieveRAG(query, {
+          topK: 5,
+        });
+      } catch (error) {
+        console.error('Blog search tool failed:', error);
+        return { error: 'Search is temporarily unavailable', results: [] };
+      }
       const baseUrl = options?.baseUrl || '';
       return {
         results: results.map((r) => ({

--- a/packages/blog/server/utils/ai/tools/search-blog.test.ts
+++ b/packages/blog/server/utils/ai/tools/search-blog.test.ts
@@ -25,10 +25,14 @@ describe('searchBlogContent', () => {
 
       expect(data.results).toBeDefined();
       expect(Array.isArray(data.results)).toBe(true);
-      expect(data.hint).toBeDefined();
-      // When DB has content, hint contains 'markdown links'; when empty, a different message
-      if (data.results.length > 0) {
-        expect(data.hint).toContain('markdown links');
+      // When DB is available, hint is present; when search fails, error is present instead
+      if (data.error) {
+        expect(data.error).toBe('Search is temporarily unavailable');
+      } else {
+        expect(data.hint).toBeDefined();
+        if (data.results.length > 0) {
+          expect(data.hint).toContain('markdown links');
+        }
       }
     });
 
@@ -111,10 +115,9 @@ describe('searchBlogContent', () => {
 
       const data = JSON.parse(result.content[0].text);
 
-      // Should return empty results array with helpful hint
+      // Should return empty results array (with hint or error depending on DB state)
       expect(data.results).toBeDefined();
       expect(Array.isArray(data.results)).toBe(true);
-      expect(data.hint).toBeDefined();
     });
   });
 });

--- a/packages/blog/server/utils/ai/tools/search-blog.ts
+++ b/packages/blog/server/utils/ai/tools/search-blog.ts
@@ -13,7 +13,16 @@ export const searchBlogContent = tool(
     query: z.string().describe('The search query to find relevant blog content'),
   },
   async (args) => {
-    const results = await retrieveRAG(args.query, { topK: 5 });
+    let results;
+    try {
+      results = await retrieveRAG(args.query, { topK: 5 });
+    } catch (error) {
+      console.error('Blog search tool failed:', error);
+      return toolResult({
+        error: 'Search is temporarily unavailable',
+        results: [],
+      });
+    }
 
     if (!results || results.length === 0) {
       return toolResult({

--- a/packages/blog/server/utils/rag/retrieve.test.ts
+++ b/packages/blog/server/utils/rag/retrieve.test.ts
@@ -50,31 +50,37 @@ describe('reciprocalRankFusion', () => {
 });
 
 describe('retrieveRAG error handling', () => {
-  it('should return empty array when embedding generation fails', async () => {
+  it('should throw when embedding generation fails', async () => {
     // Mock embedText to throw an error
     vi.spyOn(await import('../ai/bedrock'), 'embedText').mockRejectedValue(
       new Error('Bedrock API error'),
     );
 
-    const result = await retrieveRAG('test query');
-
-    expect(result).toEqual([]);
+    await expect(retrieveRAG('test query')).rejects.toThrow('Bedrock API error');
   });
 
-  it('should return empty array when database is empty', async () => {
-    // This test assumes no data in database or query that matches nothing
-    const result = await retrieveRAG('ZZZZUNLIKELYTOEXIST999');
-
-    expect(result).toBeDefined();
-    expect(Array.isArray(result)).toBe(true);
-    // May be empty or have low-relevance results
+  it('should return empty array or throw when database is unavailable', async () => {
+    // Without a running DB, retrieveRAG will throw (embedding or search failure)
+    // With a DB, it returns an empty or populated array
+    try {
+      const result = await retrieveRAG('ZZZZUNLIKELYTOEXIST999');
+      expect(result).toBeDefined();
+      expect(Array.isArray(result)).toBe(true);
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+    }
   });
 
-  it('should handle null/undefined database results gracefully', async () => {
-    // Mock database to return null rows
-    const result = await retrieveRAG('test query', { skipRerank: true });
+  it('should propagate database errors instead of silently returning empty', async () => {
+    // Mock database to simulate a connection failure
+    vi.spyOn(await import('../ai/bedrock'), 'embedText').mockResolvedValue(new Array(1024).fill(0));
+    const drizzleMod = await import('../drizzle');
+    vi.spyOn(drizzleMod, 'useDrizzle').mockImplementation(() => {
+      throw new Error('Connection refused');
+    });
 
-    expect(result).toBeDefined();
-    expect(Array.isArray(result)).toBe(true);
+    await expect(retrieveRAG('test query', { skipRerank: true })).rejects.toThrow();
+
+    vi.restoreAllMocks();
   });
 });

--- a/packages/blog/server/utils/rag/retrieve.ts
+++ b/packages/blog/server/utils/rag/retrieve.ts
@@ -77,7 +77,9 @@ async function semanticSearch(
     return results.rows as Array<ChunkCandidate & { distance: number }>;
   } catch (error) {
     console.error('Semantic search failed:', error);
-    return [];
+    throw new Error(`Semantic search failed: ${error instanceof Error ? error.message : error}`, {
+      cause: error,
+    });
   }
 }
 
@@ -116,7 +118,9 @@ async function bm25Search(
     return results.rows as Array<ChunkCandidate & { rank: number }>;
   } catch (error) {
     console.error('BM25 search failed:', error);
-    return [];
+    throw new Error(`BM25 search failed: ${error instanceof Error ? error.message : error}`, {
+      cause: error,
+    });
   }
 }
 
@@ -178,13 +182,7 @@ export async function retrieveRAG(
   const candidateCount = opts.topK * opts.candidateMultiplier;
 
   // Step 1: Generate query embedding
-  let queryEmbedding: number[];
-  try {
-    queryEmbedding = await embedText(query);
-  } catch (error) {
-    console.error('Failed to generate embedding:', error);
-    return [];
-  }
+  const queryEmbedding = await embedText(query);
 
   // Step 2: Parallel semantic and BM25 search
   const [semanticResults, bm25Results] = await Promise.all([


### PR DESCRIPTION
## Summary

- **Chat streaming**: Wrap `executeTool()` in a try/catch so a failing tool (e.g. weather API down) returns an error result to the model instead of killing the entire SSE stream
- **Stream adapter**: Replace `as unknown as Record<string, unknown>` cast with a proper `AgentToolResultPart` type; log tool input JSON parse failures instead of silently swallowing them
- **RAG search**: Make `semanticSearch` and `bm25Search` throw on DB errors instead of silently returning `[]` — callers can now distinguish "no results found" from "search infrastructure is broken"
- **Search tools**: Both `executeTool` (SDK format) and `searchBlogContent` (Agent SDK format) now catch RAG failures and return a user-friendly error message to the model

## Why

Several error paths were silently swallowing failures — a broken database connection in RAG search would return empty results with no indication anything went wrong. Tool execution failures in chat streaming would crash the entire stream instead of letting the model recover gracefully.

## Test plan

- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 239 passed, 8 skipped
- [x] Updated `retrieve.test.ts` to verify errors propagate instead of being swallowed
- [x] Updated `search-blog.test.ts` to handle both DB-available and DB-unavailable scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)