### PR TITLE
perf: extract constant objects to module scope

### DIFF
--- a/packages/blog/app/components/ChatCodeExecution.vue
+++ b/packages/blog/app/components/ChatCodeExecution.vue
@@ -1,3 +1,14 @@
+<script lang="ts">
+const LANG_MAP: Record<string, string> = {
+  python: 'python',
+  py: 'python',
+  bash: 'bash',
+  sh: 'bash',
+  javascript: 'js',
+  typescript: 'ts',
+};
+</script>
+
 <script setup lang="ts">
 import { ShikiCachedRenderer } from 'shiki-stream/vue';
 import type { CodeExecutionPart } from '~~/shared/chat-types';
@@ -10,15 +21,6 @@ const colorMode = useColorMode();
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- shiki version mismatch between shiki and shiki-stream
 const highlighter = (await useHighlighter()) as any;
 const showCode = ref(false);
-
-const LANG_MAP: Record<string, string> = {
-  python: 'python',
-  py: 'python',
-  bash: 'bash',
-  sh: 'bash',
-  javascript: 'js',
-  typescript: 'ts',
-};
 
 const lang = computed(() => LANG_MAP[props.execution.language] || props.execution.language);
 const theme = computed(() =>

--- a/packages/blog/app/components/Reasoning.vue
+++ b/packages/blog/app/components/Reasoning.vue
@@ -1,5 +1,15 @@
+<script lang="ts">
+function cleanMarkdown(text: string): string {
+  return text
+    .replace(/\*\*(.+?)\*\*/g, '$1') // Remove bold
+    .replace(/\*(.+?)\*/g, '$1') // Remove italic
+    .replace(/`(.+?)`/g, '$1') // Remove inline code
+    .replace(/^#+\s+/gm, ''); // Remove headers
+}
+</script>
+
 <script setup lang="ts">
-const { isStreaming = false } = defineProps<{
+const { text, isStreaming = false } = defineProps<{
   text: string;
   isStreaming?: boolean;
 }>();
@@ -14,13 +24,7 @@ watch(
   { immediate: true },
 );
 
-function cleanMarkdown(text: string): string {
-  return text
-    .replace(/\*\*(.+?)\*\*/g, '$1') // Remove bold
-    .replace(/\*(.+?)\*/g, '$1') // Remove italic
-    .replace(/`(.+?)`/g, '$1') // Remove inline code
-    .replace(/^#+\s+/gm, ''); // Remove headers
-}
+const lines = computed(() => cleanMarkdown(text).split('\n').filter(Boolean));
 </script>
 
 <template>
@@ -40,7 +44,7 @@ function cleanMarkdown(text: string): string {
     />
 
     <template #content>
-      <div v-for="(value, index) in cleanMarkdown(text).split('\n').filter(Boolean)" :key="index">
+      <div v-for="(value, index) in lines" :key="index">
         <span class="whitespace-pre-wrap text-sm text-muted font-normal">{{ value }}</span>
       </div>
     </template>

--- a/packages/blog/app/components/loan/ReviewCard.vue
+++ b/packages/blog/app/components/loan/ReviewCard.vue
@@ -1,12 +1,15 @@
-<script setup lang="ts">
+<script lang="ts">
 import type { DefineComponent } from 'vue';
-import type { ReviewState } from '~/composables/useLoanReview';
-import { TEST_IDS } from '~~/shared/test-ids';
 import ProsePre from '~/components/prose/ProsePre.vue';
 
 const components = {
   pre: ProsePre as unknown as DefineComponent,
 };
+</script>
+
+<script setup lang="ts">
+import type { ReviewState } from '~/composables/useLoanReview';
+import { TEST_IDS } from '~~/shared/test-ids';
 
 const props = defineProps<{
   review: ReviewState;

--- a/packages/blog/app/components/prose/ProsePre.vue
+++ b/packages/blog/app/components/prose/ProsePre.vue
@@ -1,3 +1,10 @@
+<script lang="ts">
+const LANG_MAP: Record<string, string> = {
+  javascript: 'js',
+  typescript: 'ts',
+};
+</script>
+
 <script setup lang="ts">
 import { ShikiCachedRenderer } from 'shiki-stream/vue';
 import mermaid from 'mermaid';
@@ -95,10 +102,6 @@ watch(() => colorMode.value, renderMermaid);
 const trimmedCode = computed(() => {
   return props.code.trim().replace(/`+$/, '');
 });
-const LANG_MAP: Record<string, string> = {
-  javascript: 'js',
-  typescript: 'ts',
-};
 
 const lang = computed(() => LANG_MAP[props.language] || props.language);
 const key = computed(() => {

--- a/packages/blog/app/pages/chat/[id].vue
+++ b/packages/blog/app/pages/chat/[id].vue
@@ -1,5 +1,13 @@
-<script setup lang="ts">
+<script lang="ts">
 import type { DefineComponent } from 'vue';
+import ProsePre from '../../components/prose/ProsePre.vue';
+
+const components = {
+  pre: ProsePre as unknown as DefineComponent,
+};
+</script>
+
+<script setup lang="ts">
 import { useClipboard } from '@vueuse/core';
 import type {
   ChatMessage,
@@ -8,15 +16,10 @@ import type {
   ToolUsePart,
   ToolResultPart,
 } from '~~/shared/chat-types';
-import ProsePre from '../../components/prose/ProsePre.vue';
 
 definePageMeta({
   layout: 'chat-side-nav',
 });
-
-const components = {
-  pre: ProsePre as unknown as DefineComponent,
-};
 
 const route = useRoute();
 const toast = useToast();

--- a/packages/blog/app/pages/loan/[id]/index.vue
+++ b/packages/blog/app/pages/loan/[id]/index.vue
@@ -1,13 +1,16 @@
-<script setup lang="ts">
+<script lang="ts">
 import type { DefineComponent } from 'vue';
-import type { LoanApplicationData } from '~~/shared/loan-types';
-import { isApplicationComplete } from '~~/shared/loan-types';
-import { TEST_IDS } from '~~/shared/test-ids';
 import ProsePre from '../../../components/prose/ProsePre.vue';
 
 const components = {
   pre: ProsePre as unknown as DefineComponent,
 };
+</script>
+
+<script setup lang="ts">
+import type { LoanApplicationData } from '~~/shared/loan-types';
+import { isApplicationComplete } from '~~/shared/loan-types';
+import { TEST_IDS } from '~~/shared/test-ids';
 
 definePageMeta({
   layout: 'loan',

--- a/packages/layers/reading/app/components/reading/ProgressChart.vue
+++ b/packages/layers/reading/app/components/reading/ProgressChart.vue
@@ -1,3 +1,13 @@
+<script lang="ts">
+const COLORS = {
+  skyBlue: '#4da8da',
+  orange: '#f4845f',
+  green: '#7ec8a0',
+  yellow: '#ffd166',
+  pink: '#ffb5c2',
+};
+</script>
+
 <script setup lang="ts">
 import { TEST_IDS } from '~~/shared/test-ids';
 import type { PhonicsMapUnit, SrsStatsResponse } from '../../../shared/reading-types';
@@ -7,14 +17,6 @@ const props = defineProps<{
   phonicsProgress: ReadonlyArray<{ status: string; name?: string }>;
   srsStats: SrsStatsResponse | null | undefined;
 }>();
-
-const COLORS = {
-  skyBlue: '#4da8da',
-  orange: '#f4845f',
-  green: '#7ec8a0',
-  yellow: '#ffd166',
-  pink: '#ffb5c2',
-};
 
 // WCPM trend line chart
 const wcpmOption = computed(() => {

--- a/packages/layers/reading/app/components/reading/StreakCalendar.vue
+++ b/packages/layers/reading/app/components/reading/StreakCalendar.vue
@@ -1,10 +1,4 @@
-<script setup lang="ts">
-import { TEST_IDS } from '~~/shared/test-ids';
-
-const props = defineProps<{
-  sessions: Array<{ completedAt: string }>;
-}>();
-
+<script lang="ts">
 const COLORS = {
   skyBlue: '#4da8da',
   orange: '#f4845f',
@@ -12,6 +6,14 @@ const COLORS = {
   yellow: '#ffd166',
   cream: '#fff8f0',
 };
+</script>
+
+<script setup lang="ts">
+import { TEST_IDS } from '~~/shared/test-ids';
+
+const props = defineProps<{
+  sessions: Array<{ completedAt: string }>;
+}>();
 
 const now = new Date();
 const year = now.getFullYear();

--- a/packages/layers/reading/app/components/reading/ThemeCreator.vue
+++ b/packages/layers/reading/app/components/reading/ThemeCreator.vue
@@ -1,8 +1,4 @@
-<script setup lang="ts">
-import type { ThemeConfig } from '../../composables/useReadingTheme';
-
-const { addTheme, setTheme } = useReadingTheme();
-
+<script lang="ts">
 const PRESET_COLORS = [
   '#4da8da',
   '#ffb5c2',
@@ -53,6 +49,22 @@ const MASCOT_EMOJIS = [
   '🐮',
 ];
 
+type ColorKey = 'primary' | 'secondary' | 'accent' | 'success' | 'highlight';
+
+const COLOR_FIELDS: { label: string; key: ColorKey }[] = [
+  { label: 'Primary', key: 'primary' },
+  { label: 'Secondary', key: 'secondary' },
+  { label: 'Accent', key: 'accent' },
+  { label: 'Success', key: 'success' },
+  { label: 'Highlight', key: 'highlight' },
+];
+</script>
+
+<script setup lang="ts">
+import type { ThemeConfig } from '../../composables/useReadingTheme';
+
+const { addTheme, setTheme } = useReadingTheme();
+
 const themeName = ref('');
 const primaryColor = ref(PRESET_COLORS[0]!);
 const secondaryColor = ref(PRESET_COLORS[1]!);
@@ -77,8 +89,6 @@ function loadTheme(theme: ThemeConfig) {
 
 defineExpose({ loadTheme });
 
-type ColorKey = 'primary' | 'secondary' | 'accent' | 'success' | 'highlight';
-
 const colorRefs: Record<ColorKey, Ref<string>> = {
   primary: primaryColor,
   secondary: secondaryColor,
@@ -94,14 +104,6 @@ function getColor(key: ColorKey): string {
 function setColor(key: ColorKey, value: string) {
   colorRefs[key].value = value;
 }
-
-const colorFields: { label: string; key: ColorKey }[] = [
-  { label: 'Primary', key: 'primary' },
-  { label: 'Secondary', key: 'secondary' },
-  { label: 'Accent', key: 'accent' },
-  { label: 'Success', key: 'success' },
-  { label: 'Highlight', key: 'highlight' },
-];
 
 const activeFieldKey = ref<ColorKey>('primary');
 
@@ -204,7 +206,7 @@ async function generateMagicTheme() {
     <div>
       <div class="flex gap-2 mb-2">
         <button
-          v-for="field in colorFields"
+          v-for="field in COLOR_FIELDS"
           :key="field.key"
           class="px-3 py-1 rounded-full text-xs font-bold transition-all"
           :class="

--- a/packages/layers/workflows/app/components/workflow/WorkflowSidebar.vue
+++ b/packages/layers/workflows/app/components/workflow/WorkflowSidebar.vue
@@ -1,13 +1,16 @@
-<script setup lang="ts">
+<script lang="ts">
 import type { WorkflowNodeType } from '../../../shared/workflow-types';
-import { NODE_TYPE_DEFAULTS } from '../../../shared/workflow-types';
 
-const nodeTypes: { type: WorkflowNodeType; label: string; description: string }[] = [
+const NODE_TYPES: { type: WorkflowNodeType; label: string; description: string }[] = [
   { type: 'prompt', label: 'Prompt', description: 'Freeform LLM call → structured output' },
   { type: 'transform', label: 'Transform', description: 'Reshape/extract upstream data' },
   { type: 'classifier', label: 'Classifier', description: 'Categorize into predefined classes' },
   { type: 'validator', label: 'Validator', description: 'Check constraints, return pass/fail' },
 ];
+</script>
+
+<script setup lang="ts">
+import { NODE_TYPE_DEFAULTS } from '../../../shared/workflow-types';
 
 function onDragStart(event: DragEvent, type: WorkflowNodeType) {
   if (!event.dataTransfer) return;
@@ -26,7 +29,7 @@ function onDragStart(event: DragEvent, type: WorkflowNodeType) {
 
     <div class="p-3 space-y-2 flex-1 overflow-y-auto">
       <div
-        v-for="n in nodeTypes"
+        v-for="n in NODE_TYPES"
         :key="n.type"
         draggable="true"
         class="rounded-lg border border-gray-200 dark:border-gray-700 p-3 cursor-grab hover:border-blue-300 hover:bg-blue-50 dark:hover:bg-blue-950/30 transition-colors select-none"


### PR DESCRIPTION
## Summary

- Moved constant objects (`LANG_MAP`, `COLORS`, `PRESET_COLORS`, `MASCOT_EMOJIS`, `COLOR_FIELDS`, `NODE_TYPES`, `components`) and pure functions (`cleanMarkdown`) from `<script setup>` into module-scope `<script>` blocks across 10 Vue components
- Wrapped `Reasoning.vue` template expression (`cleanMarkdown(text).split('\n').filter(Boolean)`) in a `computed` so it only recalculates when `text` changes, not on every render
- These values never change between component instances, so allocating them once per module (instead of per instance) reduces unnecessary object creation and GC pressure

## Files changed

- `ChatCodeExecution.vue` — `LANG_MAP` to module scope
- `ProsePre.vue` — `LANG_MAP` to module scope
- `Reasoning.vue` — `cleanMarkdown` to module scope + template expression wrapped in computed
- `StreakCalendar.vue` — `COLORS` to module scope
- `ProgressChart.vue` — `COLORS` to module scope
- `ThemeCreator.vue` — `PRESET_COLORS`, `MASCOT_EMOJIS`, `COLOR_FIELDS`, `ColorKey` type to module scope
- `WorkflowSidebar.vue` — `NODE_TYPES` to module scope
- `ReviewCard.vue`, `chat/[id].vue`, `loan/[id]/index.vue` — `components` map to module scope

## Test plan

- [x] `pnpm lint` passes (0 warnings, 0 errors)
- [x] `pnpm typecheck` passes
- [x] Pre-commit hooks pass (format + typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)