### PR TITLE
fix: replace `as any` type assertions with proper types

### DIFF
--- a/packages/blog/app/components/AppHeader.vue
+++ b/packages/blog/app/components/AppHeader.vue
@@ -70,11 +70,14 @@ const items = computed(() => [
     <template #right="slotProps">
       <!-- <UDashboardSearchButton :kbds="['alt', 'O']" /> -->
       <UColorModeButton v-if="!loggedIn" />
-      <UserMenu v-if="loggedIn" :collapsed="(slotProps as any)?.collapsed" />
+      <UserMenu
+        v-if="loggedIn"
+        :collapsed="(slotProps as Record<string, unknown>)?.collapsed as boolean | undefined"
+      />
 
       <UButton
         v-if="!loggedIn"
-        :label="(slotProps as any)?.collapsed ? '' : 'Login with GitHub'"
+        :label="(slotProps as Record<string, unknown>)?.collapsed ? '' : 'Login with GitHub'"
         icon="i-simple-icons-github"
         color="neutral"
         variant="ghost"

--- a/packages/blog/app/components/ChatCodeExecution.vue
+++ b/packages/blog/app/components/ChatCodeExecution.vue
@@ -2,13 +2,14 @@
 import { ShikiCachedRenderer } from 'shiki-stream/vue';
 import type { CodeExecutionPart } from '~~/shared/chat-types';
 
+type ShikiHighlighter = InstanceType<typeof ShikiCachedRenderer>['$props']['highlighter'];
+
 const props = defineProps<{
   execution: CodeExecutionPart;
 }>();
 
 const colorMode = useColorMode();
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- shiki version mismatch between shiki and shiki-stream
-const highlighter = (await useHighlighter()) as any;
+const highlighter = (await useHighlighter()) as unknown as ShikiHighlighter;
 const showCode = ref(false);
 
 const LANG_MAP: Record<string, string> = {

--- a/packages/blog/app/components/UserMenu.vue
+++ b/packages/blog/app/components/UserMenu.vue
@@ -171,8 +171,8 @@ const items = computed<DropdownMenuItem[][]>(() => [
     <template #chip-leading="{ item }">
       <span
         :style="{
-          '--color-light': `var(--color-${(item as any).chip}-500)`,
-          '--color-dark': `var(--color-${(item as any).chip}-400)`,
+          '--color-light': `var(--color-${(item as DropdownMenuItem & { chip: string }).chip}-500)`,
+          '--color-dark': `var(--color-${(item as DropdownMenuItem & { chip: string }).chip}-400)`,
         }"
         class="ms-0.5 size-2 rounded-full bg-(--color-light) dark:bg-(--color-dark)"
       />

--- a/packages/blog/app/components/prose/ProsePre.vue
+++ b/packages/blog/app/components/prose/ProsePre.vue
@@ -2,9 +2,10 @@
 import { ShikiCachedRenderer } from 'shiki-stream/vue';
 import mermaid from 'mermaid';
 
+type ShikiHighlighter = InstanceType<typeof ShikiCachedRenderer>['$props']['highlighter'];
+
 const colorMode = useColorMode();
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- shiki version mismatch between shiki and shiki-stream
-const highlighter = (await useHighlighter()) as any;
+const highlighter = (await useHighlighter()) as unknown as ShikiHighlighter;
 const props = defineProps<{
   code: string;
   language: string;

--- a/packages/blog/app/composables/useHighlighter.ts
+++ b/packages/blog/app/composables/useHighlighter.ts
@@ -1,13 +1,11 @@
+import type { Highlighter } from 'shiki';
 import { createHighlighter } from 'shiki';
-import type { HighlighterGeneric } from 'shiki';
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let highlighter: HighlighterGeneric<any, any> | null = null;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let promise: Promise<HighlighterGeneric<any, any>> | null = null;
+let highlighter: Highlighter | null = null;
+let promise: Promise<Highlighter> | null = null;
 
-export async function useHighlighter() {
+export async function useHighlighter(): Promise<Highlighter> {
   if (!promise) {
     promise = createHighlighter({
       // note: mermaid is not supported in shiki web bundle, and issue with full bundle.

--- a/packages/blog/app/composables/useSpeechRecognition.ts
+++ b/packages/blog/app/composables/useSpeechRecognition.ts
@@ -23,8 +23,7 @@ export function useSpeechRecognition(options: SpeechRecognitionOptions) {
     }>
   >([]);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let recognition: any = null;
+  let recognition: SpeechRecognition | null = null;
 
   function initFeedbacks() {
     wordFeedbacks.value = options.expectedWords.value.map(() => 'pending');
@@ -93,7 +92,7 @@ export function useSpeechRecognition(options: SpeechRecognitionOptions) {
     recognition.interimResults = true;
     recognition.lang = 'en-US';
 
-    recognition.onresult = (event: any) => {
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
       // Process only the latest final result
       for (let i = event.resultIndex; i < event.results.length; i++) {
         const result = event.results[i];
@@ -103,7 +102,7 @@ export function useSpeechRecognition(options: SpeechRecognitionOptions) {
       }
     };
 
-    recognition.onerror = (event: any) => {
+    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
       if (event.error !== 'no-speech' && event.error !== 'aborted') {
         console.warn('Speech recognition error:', event.error);
       }

--- a/packages/blog/app/pages/chat/[id].vue
+++ b/packages/blog/app/pages/chat/[id].vue
@@ -14,7 +14,7 @@ definePageMeta({
   layout: 'chat-side-nav',
 });
 
-const components = {
+const components: Record<string, DefineComponent> = {
   pre: ProsePre as unknown as DefineComponent,
 };
 
@@ -66,10 +66,13 @@ function handleSubmit(e: Event) {
 
 const copied = ref(false);
 
-function copy(e: MouseEvent, message: ChatMessage) {
-  const text = message.parts
+function copy(
+  e: MouseEvent,
+  message: { id: string; parts?: Array<{ type: string; text?: string }> },
+) {
+  const text = (message.parts ?? [])
     .filter((p) => p.type === 'text')
-    .map((p) => ('text' in p ? p.text : ''))
+    .map((p) => p.text ?? '')
     .join('\n');
 
   clipboard.copy(text);
@@ -84,6 +87,10 @@ function getPartKey(messageId: string, part: unknown, index: number) {
   const state = 'state' in part ? `-${(part as { state: string }).state}` : '';
 
   return `${messageId}-${type}-${index}${state}`;
+}
+
+function asChatMessage(msg: unknown): ChatMessage {
+  return msg as ChatMessage;
 }
 
 function getToolResult(message: ChatMessage, toolUse: ToolUsePart): ToolResultPart | undefined {
@@ -111,7 +118,7 @@ onMounted(() => {
       <UContainer>
         <UChatMessages
           should-auto-scroll
-          :messages="chat.messages.value as any"
+          :messages="chat.messages.value as ChatMessage[]"
           :status="chat.status.value"
           :assistant="
             chat.status.value !== 'streaming'
@@ -120,7 +127,7 @@ onMounted(() => {
                     {
                       label: 'Copy',
                       icon: copied ? 'i-lucide-copy-check' : 'i-lucide-copy',
-                      onClick: copy as any,
+                      onClick: copy,
                     },
                   ],
                 }
@@ -138,7 +145,7 @@ onMounted(() => {
           <template #content="{ message: rawMessage }">
             <div class="*:first:mt-0 *:last:mb-0">
               <template
-                v-for="(part, index) in (rawMessage as unknown as ChatMessage).parts"
+                v-for="(part, index) in asChatMessage(rawMessage).parts"
                 :key="getPartKey(rawMessage.id, part, index)"
               >
                 <Reasoning
@@ -149,17 +156,17 @@ onMounted(() => {
                 <ToolWeather
                   v-else-if="part.type === 'tool-use' && part.toolName === 'getWeather'"
                   :tool-use="part"
-                  :tool-result="getToolResult(rawMessage as unknown as ChatMessage, part)"
+                  :tool-result="getToolResult(asChatMessage(rawMessage), part)"
                 />
                 <ToolDice
                   v-else-if="part.type === 'tool-use' && part.toolName === 'rollDice'"
                   :tool-use="part"
-                  :tool-result="getToolResult(rawMessage as unknown as ChatMessage, part)"
+                  :tool-result="getToolResult(asChatMessage(rawMessage), part)"
                 />
                 <ToolInvocation
                   v-else-if="part.type === 'tool-use'"
                   :tool-use="part"
-                  :tool-result="getToolResult(rawMessage as unknown as ChatMessage, part)"
+                  :tool-result="getToolResult(asChatMessage(rawMessage), part)"
                 />
                 <ChatCodeExecution
                   v-else-if="part.type === 'code-execution'"

--- a/packages/blog/global.d.ts
+++ b/packages/blog/global.d.ts
@@ -6,6 +6,34 @@ declare global {
     avatar?: string;
   }
 
+  interface SpeechRecognitionEvent extends Event {
+    readonly resultIndex: number;
+    readonly results: SpeechRecognitionResultList;
+  }
+
+  interface SpeechRecognitionErrorEvent extends Event {
+    readonly error: string;
+    readonly message: string;
+  }
+
+  interface SpeechRecognition extends EventTarget {
+    continuous: boolean;
+    interimResults: boolean;
+    lang: string;
+    onresult: ((event: SpeechRecognitionEvent) => void) | null;
+    onerror: ((event: SpeechRecognitionErrorEvent) => void) | null;
+    onend: (() => void) | null;
+    start(): void;
+    stop(): void;
+    abort(): void;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-redeclare
+  const SpeechRecognition: {
+    new (): SpeechRecognition;
+    prototype: SpeechRecognition;
+  };
+
   interface Window {
     SpeechRecognition: typeof SpeechRecognition;
     webkitSpeechRecognition: typeof SpeechRecognition;


### PR DESCRIPTION
## Summary

- **useHighlighter.ts**: Replace `HighlighterGeneric<any, any>` with `Highlighter` type from shiki, add explicit return type
- **ProsePre.vue / ChatCodeExecution.vue**: Extract `ShikiHighlighter` type from `ShikiCachedRenderer` props instead of casting to `any` (shiki/shiki-stream version mismatch requires `as unknown as` but now targets the exact expected type)
- **chat/[id].vue**: Replace `as any` on messages/onClick with `asChatMessage()` helper and widened `copy()` signature; type the MDC components record
- **AppHeader.vue**: Replace `(slotProps as any)` with `(slotProps as Record<string, unknown>)` for UHeader right slot props
- **UserMenu.vue**: Replace `(item as any).chip` with `(item as DropdownMenuItem & { chip: string }).chip`
- **useSpeechRecognition.ts**: Type `recognition` as `SpeechRecognition`, event handlers as `SpeechRecognitionEvent` / `SpeechRecognitionErrorEvent`
- **global.d.ts**: Add `SpeechRecognition`, `SpeechRecognitionEvent`, and `SpeechRecognitionErrorEvent` interface declarations (Web Speech API types not in standard TS lib)

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` -- unit tests
- [ ] Verify chat page renders correctly in dev server
- [ ] Verify speech recognition still works in reading app


🤖 Generated with [Claude Code](https://claude.com/claude-code)