### PR TITLE
feat: add Zod validation to workflow client-side state (#215)

### DIFF
--- a/packages/layers/workflows/app/composables/useWorkflowRun.ts
+++ b/packages/layers/workflows/app/composables/useWorkflowRun.ts
@@ -1,4 +1,29 @@
+import { log } from 'evlog';
+import { z } from 'zod';
 import type { NodeRunStatus } from '../../shared/workflow-types';
+import {
+  startRunResponseSchema,
+  sseNodeStartSchema,
+  sseNodeCompleteSchema,
+  sseNodeErrorSchema,
+  sseRunCompleteSchema,
+  sseRunErrorSchema,
+} from '../../shared/workflow-schemas';
+
+function safeParse<T>(schema: z.ZodType<T>, raw: string, eventName: string): T | null {
+  try {
+    const json = JSON.parse(raw);
+    const result = schema.safeParse(json);
+    if (!result.success) {
+      log.warn('workflow-run', `Invalid ${eventName} SSE payload: ${String(result.error)}`);
+      return null;
+    }
+    return result.data;
+  } catch {
+    log.warn('workflow-run', `Failed to parse ${eventName} SSE data`);
+    return null;
+  }
+}
 
 export function useWorkflowRun(workflowId: string) {
   const runStatus = ref(new Map<string, NodeRunStatus>());
@@ -22,10 +47,12 @@ export function useWorkflowRun(workflowId: string) {
 
     let runId: string;
     try {
-      ({ runId } = await $fetch<{ runId: string }>(`/api/workflows/${workflowId}/run`, {
+      const raw = await $fetch(`/api/workflows/${workflowId}/run`, {
         method: 'POST',
         body: { input },
-      }));
+      });
+      const parsed = startRunResponseSchema.parse(raw);
+      runId = parsed.runId;
     } catch (err) {
       runError.value = err instanceof Error ? err.message : 'Failed to start run';
       isRunning.value = false;
@@ -38,20 +65,16 @@ export function useWorkflowRun(workflowId: string) {
     eventSource.value = es;
 
     es.addEventListener('node:start', (e) => {
-      const { nodeId } = JSON.parse(e.data) as { nodeId: string };
+      const data = safeParse(sseNodeStartSchema, e.data, 'node:start');
+      if (!data) return;
       const next = new Map(runStatus.value);
-      next.set(nodeId, { status: 'running' });
+      next.set(data.nodeId, { status: 'running' });
       runStatus.value = next;
     });
 
     es.addEventListener('node:complete', (e) => {
-      const data = JSON.parse(e.data) as {
-        nodeId: string;
-        output: Record<string, unknown>;
-        tokensIn: number;
-        tokensOut: number;
-        latencyMs: number;
-      };
+      const data = safeParse(sseNodeCompleteSchema, e.data, 'node:complete');
+      if (!data) return;
       const next = new Map(runStatus.value);
       next.set(data.nodeId, {
         status: 'completed',
@@ -64,22 +87,25 @@ export function useWorkflowRun(workflowId: string) {
     });
 
     es.addEventListener('node:error', (e) => {
-      const { nodeId, error } = JSON.parse(e.data) as { nodeId: string; error: string };
+      const data = safeParse(sseNodeErrorSchema, e.data, 'node:error');
+      if (!data) return;
       const next = new Map(runStatus.value);
-      next.set(nodeId, { status: 'failed', error });
+      next.set(data.nodeId, { status: 'failed', error: data.error });
       runStatus.value = next;
     });
 
     es.addEventListener('run:complete', (e) => {
-      finalOutput.value = (
-        JSON.parse(e.data) as { output: Record<string, Record<string, unknown>> }
-      ).output;
+      const data = safeParse(sseRunCompleteSchema, e.data, 'run:complete');
+      if (!data) return;
+      finalOutput.value = data.output;
       isRunning.value = false;
       closeEventSource();
     });
 
     es.addEventListener('run:error', (e) => {
-      runError.value = (JSON.parse(e.data) as { error: string }).error;
+      const data = safeParse(sseRunErrorSchema, e.data, 'run:error');
+      if (!data) return;
+      runError.value = data.error;
       isRunning.value = false;
       closeEventSource();
     });

--- a/packages/layers/workflows/app/pages/workflows/[id].vue
+++ b/packages/layers/workflows/app/pages/workflows/[id].vue
@@ -6,26 +6,37 @@ import { MiniMap } from '@vue-flow/minimap';
 import '@vue-flow/core/dist/style.css';
 import '@vue-flow/core/dist/theme-default.css';
 import type { Node, Edge, NodeTypesObject, ViewportTransform } from '@vue-flow/core';
+import { log } from 'evlog';
 import type { WorkflowNodeType } from '../../../shared/workflow-types';
 import { NODE_TYPE_DEFAULTS } from '../../../shared/workflow-types';
+import {
+  workflowDetailResponseSchema,
+  workflowEditorQuerySchema,
+} from '../../../shared/workflow-schemas';
 
 definePageMeta({ middleware: 'auth' });
-
-interface WorkflowResponse {
-  id: string;
-  name: string;
-  description: string | null;
-  viewport: ViewportTransform | null;
-  version: number;
-  nodes: Node[];
-  edges: Edge[];
-}
 
 const route = useRoute();
 const router = useRouter();
 const workflowId = route.params.id as string;
 
-const { data: workflow } = await useFetch<WorkflowResponse>(`/api/workflows/${workflowId}`);
+// Validate URL query params at page load
+const queryResult = workflowEditorQuerySchema.safeParse(route.query);
+if (!queryResult.success) {
+  log.warn('workflow-editor', `Invalid URL query params, resetting: ${String(queryResult.error)}`);
+  await router.replace({ query: {} });
+}
+
+const { data: workflow } = await useFetch(`/api/workflows/${workflowId}`, {
+  transform: (raw) => {
+    const result = workflowDetailResponseSchema.safeParse(raw);
+    if (!result.success) {
+      log.warn('workflow-editor', `Invalid workflow API response: ${String(result.error)}`);
+      return null;
+    }
+    return result.data;
+  },
+});
 
 if (!workflow.value) {
   throw createError({ statusCode: 404, message: 'Workflow not found' });

--- a/packages/layers/workflows/app/pages/workflows/index.vue
+++ b/packages/layers/workflows/app/pages/workflows/index.vue
@@ -1,8 +1,20 @@
 <script setup lang="ts">
+import { log } from 'evlog';
+import { workflowListResponseSchema } from '../../../shared/workflow-schemas';
+
 definePageMeta({ middleware: 'auth' });
 useSeoMeta({ title: 'Workflows' });
 
-const { data: workflows, refresh } = await useFetch('/api/workflows');
+const { data: workflows, refresh } = await useFetch('/api/workflows', {
+  transform: (raw) => {
+    const result = workflowListResponseSchema.safeParse(raw);
+    if (!result.success) {
+      log.warn('workflow-list', `Invalid workflow list API response: ${String(result.error)}`);
+      return [];
+    }
+    return result.data;
+  },
+});
 
 const newName = ref('');
 const creating = ref(false);

--- a/packages/layers/workflows/package.json
+++ b/packages/layers/workflows/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "type": "module",
   "main": "./nuxt.config.ts",
+  "dependencies": {
+    "evlog": "^2.11.0",
+    "zod": "^4.3.4"
+  },
   "devDependencies": {
     "@vue-flow/background": "^1.3.2",
     "@vue-flow/controls": "^1.1.3",

--- a/packages/layers/workflows/shared/workflow-schemas.ts
+++ b/packages/layers/workflows/shared/workflow-schemas.ts
@@ -1,0 +1,121 @@
+/**
+ * Zod schemas for validating workflow data at system boundaries:
+ * - API responses parsed on the client
+ * - SSE event payloads from the workflow run stream
+ * - URL query params on the editor page
+ *
+ * These schemas validate external data flowing into the client.
+ * Internal state (VueFlow refs, composable returns) is not validated here.
+ */
+
+import { z } from 'zod';
+
+// ── URL query params for the workflow editor page ──
+
+export const workflowEditorQuerySchema = z.object({
+  node: z.string().optional(),
+  tab: z.enum(['edit', 'run']).optional(),
+});
+
+export type WorkflowEditorQuery = z.infer<typeof workflowEditorQuerySchema>;
+
+// ── Viewport ──
+
+export const viewportSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  zoom: z.number(),
+});
+
+// ── Node data shape (matches what the GET /api/workflows/:id endpoint returns) ──
+
+export const workflowNodeDataSchema = z.object({
+  label: z.string(),
+  prompt: z.string(),
+  model: z.string(),
+  temperature: z.number(),
+  maxTokens: z.number(),
+  outputSchema: z.record(z.string(), z.unknown()),
+  inputMapping: z.record(z.string(), z.string()).optional(),
+});
+
+export const workflowNodeSchema = z.object({
+  id: z.string(),
+  type: z.enum(['prompt', 'transform', 'classifier', 'validator']),
+  position: z.object({ x: z.number(), y: z.number() }),
+  data: workflowNodeDataSchema,
+});
+
+export const workflowEdgeSchema = z.object({
+  id: z.string(),
+  source: z.string(),
+  target: z.string(),
+  sourceHandle: z.string().optional(),
+  targetHandle: z.string().optional(),
+  label: z.string().optional(),
+  animated: z.boolean().optional(),
+  type: z.string().optional(),
+});
+
+// ── GET /api/workflows/:id response ──
+
+export const workflowDetailResponseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  viewport: viewportSchema,
+  version: z.number(),
+  nodes: z.array(workflowNodeSchema),
+  edges: z.array(workflowEdgeSchema),
+});
+
+export type WorkflowDetailResponse = z.infer<typeof workflowDetailResponseSchema>;
+
+// ── GET /api/workflows (list) response ──
+
+export const workflowListItemSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  version: z.number(),
+  isTemplate: z.number(),
+  updatedAt: z.string().nullable(),
+});
+
+export const workflowListResponseSchema = z.array(workflowListItemSchema);
+
+export type WorkflowListItem = z.infer<typeof workflowListItemSchema>;
+
+// ── POST /api/workflows/:id/run response ──
+
+export const startRunResponseSchema = z.object({
+  runId: z.string(),
+});
+
+// ── SSE event payloads from the workflow run stream ──
+
+export const sseNodeStartSchema = z.object({
+  nodeId: z.string(),
+  label: z.string().optional(),
+});
+
+export const sseNodeCompleteSchema = z.object({
+  nodeId: z.string(),
+  output: z.record(z.string(), z.unknown()),
+  tokensIn: z.number(),
+  tokensOut: z.number(),
+  latencyMs: z.number(),
+});
+
+export const sseNodeErrorSchema = z.object({
+  nodeId: z.string(),
+  error: z.string(),
+});
+
+export const sseRunCompleteSchema = z.object({
+  output: z.record(z.string(), z.record(z.string(), z.unknown())),
+});
+
+export const sseRunErrorSchema = z.object({
+  error: z.string(),
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,6 +264,13 @@ importers:
         version: 4.3.5
 
   packages/layers/workflows:
+    dependencies:
+      evlog:
+        specifier: ^2.11.0
+        version: 2.11.0(@nuxt/kit@4.4.2(magicast@0.5.1))(ofetch@1.5.1)(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      zod:
+        specifier: ^4.3.4
+        version: 4.3.5
     devDependencies:
       '@vue-flow/background':
         specifier: ^1.3.2


### PR DESCRIPTION
## Summary
- Add Zod schemas for all workflow system boundaries in `packages/layers/workflows/shared/workflow-schemas.ts`
- Validate API responses in workflow detail/list pages via `useFetch` transform
- Validate SSE events in `useWorkflowRun` composable with `safeParse` — invalid payloads logged and dropped
- Validate URL query params on workflow editor page load

Fixes #215

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)