### PR TITLE
feat: add Google OAuth login support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,11 @@ NUXT_OAUTH_GITHUB_CLIENT_ID=
 # GitHub OAuth client secret
 NUXT_OAUTH_GITHUB_CLIENT_SECRET=
 
+#### Google OAuth ###
+# https://console.cloud.google.com/apis/credentials
+NUXT_OAUTH_GOOGLE_CLIENT_ID=
+NUXT_OAUTH_GOOGLE_CLIENT_SECRET=
+
 
 # AWS Bedrock (for RAG embeddings/reranking)
 AWS_REGION=us-east-1

--- a/docs/google-login-setup.md
+++ b/docs/google-login-setup.md
@@ -1,0 +1,121 @@
+# Google Login Setup
+
+Google OAuth login for the blog, using `nuxt-auth-utils` with `defineOAuthGoogleEventHandler`.
+
+## Architecture
+
+```
+User clicks "Sign in with Google" on /login
+  -> Redirects to /auth/google
+  -> nuxt-auth-utils handles OAuth flow with Google
+  -> Google redirects back to /auth/google with auth code
+  -> Server exchanges code for user info (sub, name, email, picture)
+  -> User created/found in DB, session set
+  -> Redirects to original page
+```
+
+## Prerequisites
+
+- GCP project with Google Auth Platform configured
+- OAuth consent screen (External, published)
+- OAuth 2.0 Client ID (Web application type)
+- Secrets stored in GCP Secret Manager
+
+## Setup Per Environment
+
+Each GCP project (prod, staging) needs its own OAuth client with environment-specific redirect URIs.
+
+### 1. Configure OAuth Consent Screen
+
+Go to: `https://console.cloud.google.com/auth/overview/create?project=<PROJECT_ID>`
+
+| Field | Value |
+|-------|-------|
+| App name | Chris Towles Blog |
+| User support email | chris.towles@gmail.com |
+| Audience | External |
+| Contact email | support@towles.dev |
+
+After creation, go to **Audience** and publish the app to move from Testing to Production mode.
+
+### 2. Create OAuth Client
+
+Go to: `https://console.cloud.google.com/auth/clients/create?project=<PROJECT_ID>`
+
+| Field | Value |
+|-------|-------|
+| Application type | Web application |
+| Name | Blog Web Client |
+| Authorized redirect URIs | See table below |
+
+#### Redirect URIs by Environment
+
+| Environment | Redirect URI |
+|-------------|-------------|
+| Production | `https://chris.towles.dev/auth/google` |
+| Staging | `https://staging-chris.towles.dev/auth/google` |
+| Local dev | `http://localhost:3000/auth/google` |
+
+Add the local dev URI to whichever OAuth client you use for development.
+
+### 3. Store Secrets in GCP Secret Manager
+
+```bash
+# Create secrets
+echo -n "<CLIENT_ID>" | gcloud secrets create google-oauth-client-id \
+  --project=<PROJECT_ID> --data-file=- --replication-policy=automatic
+
+echo -n "<CLIENT_SECRET>" | gcloud secrets create google-oauth-client-secret \
+  --project=<PROJECT_ID> --data-file=- --replication-policy=automatic
+
+# Grant Cloud Run service account access
+gcloud secrets add-iam-policy-binding google-oauth-client-id \
+  --project=<PROJECT_ID> \
+  --member="serviceAccount:cloud-run@<PROJECT_ID>.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+
+gcloud secrets add-iam-policy-binding google-oauth-client-secret \
+  --project=<PROJECT_ID> \
+  --member="serviceAccount:cloud-run@<PROJECT_ID>.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+```
+
+### 4. Terraform
+
+The secrets are wired through Terraform modules:
+
+- `modules/shared/main.tf` — `data` sources for Secret Manager secrets
+- `modules/shared/outputs.tf` — exposes secret IDs
+- `modules/cloud-run/variables.tf` — accepts secret ID variables
+- `modules/cloud-run/main.tf` — injects as `NUXT_OAUTH_GOOGLE_CLIENT_ID` and `NUXT_OAUTH_GOOGLE_CLIENT_SECRET` env vars
+- `environments/*/main.tf` — passes secret IDs from shared to cloud-run
+
+Run `terraform apply` after adding secrets to deploy.
+
+### 5. Local Development
+
+Add to your `.env`:
+
+```bash
+NUXT_OAUTH_GOOGLE_CLIENT_ID=<client-id-from-gcp>
+NUXT_OAUTH_GOOGLE_CLIENT_SECRET=<client-secret-from-gcp>
+```
+
+## Support Email
+
+`support@towles.dev` is configured via Cloudflare Email Routing, forwarding to `chris.towles@gmail.com`. DNS records (MX, SPF, DKIM) are managed automatically by Cloudflare.
+
+## Code References
+
+- Login page: `packages/blog/app/pages/login.vue`
+- Google OAuth handler: `packages/blog/server/routes/auth/google.get.ts`
+- GitHub OAuth handler: `packages/blog/server/routes/auth/github.get.ts`
+- Env validation: `packages/blog/server/utils/env-config.ts`
+- DB schema (users table): `packages/blog/server/database/schema/blog.ts`
+
+## GCP Projects
+
+| Environment | Project ID | Domain |
+|-------------|-----------|--------|
+| Production | blog-towles-production | chris.towles.dev |
+| Staging | blog-towles-staging | staging-chris.towles.dev |

--- a/infra/terraform/environments/main.tf
+++ b/infra/terraform/environments/main.tf
@@ -55,6 +55,8 @@ module "cloud_run" {
   aws_secret_access_key_secret_id      = module.shared.aws_secret_access_key_secret_id
   github_oauth_client_id_secret_id     = module.shared.github_oauth_client_id_secret_id
   github_oauth_client_secret_secret_id = module.shared.github_oauth_client_secret_secret_id
+  google_oauth_client_id_secret_id     = module.shared.google_oauth_client_id_secret_id
+  google_oauth_client_secret_secret_id = module.shared.google_oauth_client_secret_secret_id
   braintrust_api_key_secret_id         = module.shared.braintrust_api_key_secret_id
   braintrust_project_name              = var.braintrust_project_name
   site_url                             = var.site_url

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -67,6 +67,8 @@ module "cloud_run" {
   aws_secret_access_key_secret_id      = module.shared.aws_secret_access_key_secret_id
   github_oauth_client_id_secret_id     = module.shared.github_oauth_client_id_secret_id
   github_oauth_client_secret_secret_id = module.shared.github_oauth_client_secret_secret_id
+  google_oauth_client_id_secret_id     = module.shared.google_oauth_client_id_secret_id
+  google_oauth_client_secret_secret_id = module.shared.google_oauth_client_secret_secret_id
   braintrust_api_key_secret_id         = module.shared.braintrust_api_key_secret_id
   braintrust_project_name              = "blog-prod"
   site_url                             = var.site_url

--- a/infra/terraform/environments/staging/main.tf
+++ b/infra/terraform/environments/staging/main.tf
@@ -177,6 +177,8 @@ module "cloud_run" {
   aws_secret_access_key_secret_id      = module.shared.aws_secret_access_key_secret_id
   github_oauth_client_id_secret_id     = module.shared.github_oauth_client_id_secret_id
   github_oauth_client_secret_secret_id = module.shared.github_oauth_client_secret_secret_id
+  google_oauth_client_id_secret_id     = module.shared.google_oauth_client_id_secret_id
+  google_oauth_client_secret_secret_id = module.shared.google_oauth_client_secret_secret_id
   braintrust_api_key_secret_id         = module.shared.braintrust_api_key_secret_id
   braintrust_project_name              = "blog-stage"
   site_url                             = var.site_url

--- a/infra/terraform/modules/cloud-run/main.tf
+++ b/infra/terraform/modules/cloud-run/main.tf
@@ -128,6 +128,32 @@ resource "google_cloud_run_v2_service" "main" {
       }
 
       dynamic "env" {
+        for_each = var.google_oauth_client_id_secret_id != "" ? [1] : []
+        content {
+          name = "NUXT_OAUTH_GOOGLE_CLIENT_ID"
+          value_source {
+            secret_key_ref {
+              secret  = var.google_oauth_client_id_secret_id
+              version = "latest"
+            }
+          }
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.google_oauth_client_secret_secret_id != "" ? [1] : []
+        content {
+          name = "NUXT_OAUTH_GOOGLE_CLIENT_SECRET"
+          value_source {
+            secret_key_ref {
+              secret  = var.google_oauth_client_secret_secret_id
+              version = "latest"
+            }
+          }
+        }
+      }
+
+      dynamic "env" {
         for_each = var.braintrust_api_key_secret_id != "" ? [1] : []
         content {
           name = "BRAINTRUST_API_KEY"

--- a/infra/terraform/modules/cloud-run/variables.tf
+++ b/infra/terraform/modules/cloud-run/variables.tf
@@ -103,6 +103,16 @@ variable "github_oauth_client_secret_secret_id" {
   type        = string
 }
 
+variable "google_oauth_client_id_secret_id" {
+  description = "Secret Manager secret ID for Google OAuth client ID"
+  type        = string
+}
+
+variable "google_oauth_client_secret_secret_id" {
+  description = "Secret Manager secret ID for Google OAuth client secret"
+  type        = string
+}
+
 variable "braintrust_api_key_secret_id" {
   description = "Secret Manager secret ID for Braintrust API key"
   type        = string

--- a/infra/terraform/modules/shared/main.tf
+++ b/infra/terraform/modules/shared/main.tf
@@ -78,6 +78,16 @@ data "google_secret_manager_secret" "github_oauth_client_secret" {
   project   = var.project_id
 }
 
+data "google_secret_manager_secret" "google_oauth_client_id" {
+  secret_id = "google-oauth-client-id"
+  project   = var.project_id
+}
+
+data "google_secret_manager_secret" "google_oauth_client_secret" {
+  secret_id = "google-oauth-client-secret"
+  project   = var.project_id
+}
+
 data "google_secret_manager_secret" "braintrust_api_key" {
   secret_id = "braintrust-api-key"
   project   = var.project_id

--- a/infra/terraform/modules/shared/outputs.tf
+++ b/infra/terraform/modules/shared/outputs.tf
@@ -48,6 +48,16 @@ output "github_oauth_client_secret_secret_id" {
   value       = data.google_secret_manager_secret.github_oauth_client_secret.secret_id
 }
 
+output "google_oauth_client_id_secret_id" {
+  description = "Secret Manager secret ID for Google OAuth client ID"
+  value       = data.google_secret_manager_secret.google_oauth_client_id.secret_id
+}
+
+output "google_oauth_client_secret_secret_id" {
+  description = "Secret Manager secret ID for Google OAuth client secret"
+  value       = data.google_secret_manager_secret.google_oauth_client_secret.secret_id
+}
+
 output "braintrust_api_key_secret_id" {
   description = "Secret Manager secret ID for Braintrust API key"
   value       = data.google_secret_manager_secret.braintrust_api_key.secret_id

--- a/packages/blog/server/utils/env-config.ts
+++ b/packages/blog/server/utils/env-config.ts
@@ -22,6 +22,10 @@ export const envSchema = z.object({
   NUXT_OAUTH_GITHUB_CLIENT_ID: z.string().min(1, 'NUXT_OAUTH_GITHUB_CLIENT_ID is required'),
   NUXT_OAUTH_GITHUB_CLIENT_SECRET: z.string().min(1, 'NUXT_OAUTH_GITHUB_CLIENT_SECRET is required'),
 
+  // Google OAuth
+  NUXT_OAUTH_GOOGLE_CLIENT_ID: z.string().min(1, 'NUXT_OAUTH_GOOGLE_CLIENT_ID is required'),
+  NUXT_OAUTH_GOOGLE_CLIENT_SECRET: z.string().min(1, 'NUXT_OAUTH_GOOGLE_CLIENT_SECRET is required'),
+
   // Google AI (Gemini) — optional, used for story illustrations
   GOOGLE_AI_API_KEY: z.string().optional().default(''),
 


### PR DESCRIPTION
## Summary

- Add Google OAuth as a login provider alongside GitHub, using the existing `nuxt-auth-utils` handler at `/auth/google`
- Wire credentials through GCP Secret Manager → Terraform → Cloud Run env vars, matching the established GitHub OAuth pattern
- Add `support@towles.dev` email via Cloudflare Email Routing for OAuth consent screen contact
- Add setup documentation at `docs/google-login-setup.md`

## Changes

**App code** — Added `NUXT_OAUTH_GOOGLE_CLIENT_ID` and `NUXT_OAUTH_GOOGLE_CLIENT_SECRET` to `.env.example` and Zod validation in `env-config.ts`. The OAuth handler (`server/routes/auth/google.get.ts`) and login page already existed.

**Terraform** — Added `google-oauth-client-id` and `google-oauth-client-secret` Secret Manager data sources in `shared`, exposed as outputs, and injected into Cloud Run via dynamic env blocks. Applied to all three environment configs (default, prod, staging).

**GCP setup (production)** — OAuth consent screen configured (External, app name "Chris Towles Blog"), OAuth client created with redirect URIs for `chris.towles.dev` and `localhost:3000`. Secrets stored in Secret Manager with Cloud Run SA access granted.

## Remaining work

- [ ] Create staging OAuth consent screen + client in `blog-towles-staging`
- [ ] Publish OAuth apps from Testing → Production mode (both projects)
- [ ] Run `terraform apply` for prod and staging
- [ ] Verify Google login end-to-end

---

[![Compound Engineering v2.62.1](https://img.shields.io/badge/Compound_Engineering-v2.62.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)