### PR TITLE
fix: resolve pg-pool ESM/CJS conflict in Vitest tests

### DIFF
--- a/packages/blog/vitest.config.ts
+++ b/packages/blog/vitest.config.ts
@@ -7,6 +7,22 @@ export default defineConfig({
   test: {
     projects: [
       await defineVitestProject({
+        plugins: [
+          {
+            // Nuxt adds 'import' to SSR resolve conditions, which causes
+            // Node 24's require() to load ESM pg-pool instead of CJS,
+            // breaking pg's class extends. See vitest-dev/vitest#10012
+            name: 'fix-pg-pool-esm',
+            enforce: 'post',
+            configEnvironment(name, config) {
+              if (name === 'ssr') {
+                config.resolve!.conditions = config.resolve!.conditions!.filter(
+                  (c: string) => c !== 'import',
+                );
+              }
+            },
+          },
+        ],
         test: {
           name: 'nuxt',
           testTimeout: 60_000,


### PR DESCRIPTION
## Summary

- Fixes all 4 test files that were failing with `TypeError: Class extends value [object Module] is not a constructor or null`
- Root cause: Nuxt adds `import` to SSR resolve conditions, causing Node 24's `require('pg-pool')` to load the ESM entry instead of CJS
- Fix: Vite plugin that strips `import` from SSR conditions (workaround from vitest-dev/vitest#10012)
- Unblocks CI deploy pipeline — all 10+ recent deploys were failing due to this

## Test results

Before: 4 test files failed, 20 passed
After: 23 test files passed, 1 skipped (agent.test.ts — describe.skip)