### PR TITLE
feat(gcp-billing): spend-cap kill-switch + BigQuery export (Phase 1 applied)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,8 @@ packages/
 infra/              # infrastructure
     container/       # block docker files
     aws_cloudformation/ # AWS Bedrock and IAM
-    terraform/          # GCP Cloud Run and Cloud SQL
+    terraform/          # GCP Cloud Run and Cloud SQL (blog hosting stack)
+    gcp-billing/        # GCP spend-cap kill-switch + BigQuery export (separate stack)
 ```
 
 ## Hosting
@@ -81,8 +82,16 @@ Don't claim a feature works without steps 4-6. Automated tests miss rendering is
 ## Pre-commit Hooks
 
 - Image compression requires `pngquant` (`sudo apt-get install pngquant`)
+- `oxlint --fix` + `oxfmt --write` run via lint-staged on staged JS/TS/MD files. They reformat markdown tables, emphasis (`*x*` → `_x_`), and string quotes. Expect a follow-up commit to reach formatter fixed-point after edits to docs.
+- Use conventional commits with scopes: `feat(scope):`, `fix(scope):`, `style(scope):`, `chore(scope):`. Match existing scopes from `git log` (e.g., `gcp-billing`, `og-image`, `workflows`, `terraform`).
 
 ## References
 
 - [GCP: Hosting](docs/hosting.md)
 - [Terraform Details](infra/terraform/README.md)
+- [GCP Spend-Cap Kill-Switch](infra/gcp-billing/README.md)
+
+## Terraform
+
+- Terraform state lives in GCS bucket `blog-towles-production-tfstate`, keyed per stack via `prefix` (e.g., `terraform/state` for blog hosting, `terraform/gcp-billing` for the kill-switch). New stacks should pick a new unique prefix rather than creating another bucket.
+- Cloud Function source convention: upload zips to `${project_id}-functions` GCS bucket (each stack creates its own objects keyed by content hash). See `infra/terraform/modules/cost-scheduler/` and `infra/gcp-billing/pubsub_function.tf` for examples.

--- a/docs/plans/2026-04-14-001-feat-gcp-billing-killswitch-rollout-plan.md
+++ b/docs/plans/2026-04-14-001-feat-gcp-billing-killswitch-rollout-plan.md
@@ -1,0 +1,652 @@
+---
+title: "feat: Roll out GCP billing kill-switch + BigQuery export"
+type: feat
+status: active
+date: 2026-04-14
+deepened: 2026-04-14
+---
+
+# feat: Roll out GCP billing kill-switch + BigQuery export
+
+## Overview
+
+Operational rollout of the already-authored `infra/gcp-billing/` Terraform stack. Phase 1
+provisions the shared infra (Pub/Sub topic, kill-switch Cloud Function, service account,
+BigQuery dataset) without any budgets. A 1–2 week observation window then yields real
+per-project spend data from the BigQuery export. Phase 2 fills in `project_caps` with
+informed numbers and applies again, arming a per-project kill-switch that disables
+billing on any project that crosses its monthly cap.
+
+## Problem Frame
+
+GCP has no native hard spend cap. All six projects under billing account
+`015529-D0D3BB-5BEDEE` — including personal experiments like `jarvis-home-487516` —
+are currently exposed to unbounded spend if something goes wrong (runaway Cloud Run
+instances, buggy Cloud SQL query loops, API abuse). The stack built during the
+previous session implements Google's canonical pattern for a *reactive* kill-switch
+(budget → Pub/Sub → function → `updateBillingInfo`). This plan is about safely putting
+it into operation without guessing at cap values that could trip under normal load.
+
+### Known Limitations of the Mechanism
+
+- **Cloud Billing budget notifications lag actual spend by ~4–24 hours.** This is
+  inherent to how Google aggregates cost data — no billing-side mechanism (console
+  budgets, BQ-export-based alerts, Cloud Monitoring billing metrics, third-party
+  tools) reads from faster-than-lagging data. A sudden spike can multiply spend
+  several times over the cap before the trip fires. Caps should be sized assuming
+  burn-through is possible ("I'm willing to spend up to N× the cap in a worst-case
+  incident before the kill-switch catches up").
+- **Preventive quotas are a separate, complementary mechanism** — not a replacement.
+  Cloud Run `max_instances`, Cloud SQL tier limits, per-API quotas, and organization
+  policies constrain resource creation in real time. They're out of scope here but
+  worth considering as a follow-up layer; the right overall design is *quotas for
+  prevention + kill-switch for the long tail*.
+- **Self-kill is acceptable.** If `blog-towles-production` (the host project) trips
+  its own cap, the function calls `updateBillingInfo` synchronously before its own
+  billing is disabled, so the kill itself completes. After that, the Pub/Sub topic
+  and function go offline until the host is manually re-linked — meaning other
+  projects are temporarily unprotected from *new* trips. Accepted on the basis that
+  (a) trips are rare, (b) if prod blew its cap you have bigger problems and will
+  notice, (c) the alternative (a dedicated admin project) is heavier than the risk
+  warrants for a personal-scale setup.
+
+## Requirements Trace
+
+- **R1.** Kill-switch infrastructure is live on `blog-towles-production` (host project)
+  and armed-but-inert until caps are set.
+- **R2.** BigQuery billing export is actively landing data from billing account
+  `015529-D0D3BB-5BEDEE` into `blog-towles-production.billing_export`.
+- **R3.** Per-project spend baseline is documented from at least 7 days of real export
+  data before any cap is set.
+- **R4.** Every project on the billing account has a cap — no gaps.
+- **R5.** Cap values include enough headroom (≥2× observed baseline or a floor, whichever
+  is higher) to avoid tripping under normal usage.
+- **R6.** The function is verified to work end-to-end (at least a dry-run) before caps
+  are armed, so tripping behavior isn't discovered for the first time during a real
+  incident.
+- **R7.** Re-enable procedure is known and documented (the code handles this already;
+  this plan just verifies the user has run through it once in thought).
+
+## Scope Boundaries
+
+- Not redesigning the Terraform stack — only applying and validating it.
+- Not adding email/Slack notifications when billing gets disabled. (Default IAM
+  recipients on the budget notify the billing admin by email; that's sufficient for v1.)
+- Not adding dead-letter queue on Pub/Sub failures.
+- Not tuning caps beyond a first informed pass; iteration will happen naturally month
+  over month.
+- Not setting per-service quotas (`compute.googleapis.com` quotas, etc.).
+- Not migrating existing terraform stacks (`infra/terraform/`) to share state or
+  modules with `infra/gcp-billing/`.
+
+### Deferred to Separate Tasks
+
+- **Alerting/notification on billing disable event:** Follow-on work. The current
+  behavior is: budget sends email to billing admin + function writes Cloud Logging
+  entry. Upgrading to Slack/pager requires a second Pub/Sub subscription or a
+  logs-based alerting policy.
+- **Per-service preventive quotas** (Cloud Run `max_instances`, Cloud SQL tier caps,
+  API-per-minute quotas): the complementary mechanism that makes reactive caps less
+  load-bearing. Worth a follow-up plan once this one is rolled out.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `infra/gcp-billing/main.tf` — providers, backend, API enablement
+- `infra/gcp-billing/bigquery_export.tf` — BQ dataset + IAM for billing-export SA
+- `infra/gcp-billing/pubsub_function.tf` — Pub/Sub topic, runtime SA, 2nd-gen function
+- `infra/gcp-billing/budgets.tf` — `google_billing_budget` resources, for_each over
+  `var.project_caps` (default `{}`)
+- `infra/gcp-billing/function/index.js` — Node.js 20 handler; parses
+  `budgetDisplayName = spend-cap-<project_id>`; idempotent on
+  `billingEnabled == false`
+- `infra/gcp-billing/terraform.tfvars` — authoritative cap map; currently `{}`
+- `infra/gcp-billing/README.md` — has the console enable URL, synthetic-publish
+  test commands, and re-enable steps already written
+- `infra/terraform/modules/cost-scheduler/` — prior-art Cloud Function deployment
+  pattern that `gcp-billing/` is modeled after (same GCS source bucket shape, same
+  `googleapis` npm package, same 2nd-gen layout)
+
+### Institutional Learnings
+
+No `docs/solutions/` directory in this repo. Relevant lessons from this session's
+context:
+
+- **Billing export cannot be provisioned by Terraform.** The google provider has no
+  resource for `billingAccounts.updateBillingExport`. Dataset + IAM via TF; enable via
+  console. This is why Unit 2 exists as a standalone manual step.
+- **`budget_filter.projects` requires project *numbers*, not IDs.** `budgets.tf`
+  already handles this via `data "google_project"` lookup — worth flagging if any of
+  the 6 projects fail to resolve.
+- **`roles/billing.projectManager` on the billing account (not a project) is the
+  minimal role needed to call `updateBillingInfo` with an empty `billingAccountName`.**
+  Already encoded in `pubsub_function.tf`.
+
+### External References
+
+- <https://cloud.google.com/billing/docs/how-to/notify#cap_disable_billing> — the
+  canonical pattern this stack implements.
+- <https://cloud.google.com/billing/docs/how-to/export-data-bigquery-setup> — manual
+  console enable procedure for BQ export.
+
+## Key Technical Decisions
+
+- **Two-phase rollout instead of one.** Phase 1 provisions everything but budgets;
+  Phase 2 adds budgets after real spend data exists. Rationale: setting caps without
+  baseline data risks tripping production under normal load; the extra apply has
+  negligible cost and maximum safety.
+- **Host everything in `blog-towles-production`.** Most stable project, already holds
+  the existing TF state bucket, already has the most mature IAM. Self-kill (the host
+  project tripping its own cap) is an accepted limitation, documented in Problem Frame.
+- **Use `roles/billing.admin` on the function SA, not `roles/billing.projectManager`.**
+  Matches Google's canonical sample and eliminates uncertainty about whether the
+  narrower role is sufficient for `updateBillingInfo` with an empty
+  `billingAccountName`. Tradeoff: slightly broader role, but scoped to this billing
+  account only and used by a single function.
+- **Budget `displayName = spend-cap-<project_id>` is load-bearing.** It's the only
+  link between the budget notification and the project the function should kill.
+  The function enforces an allowlist (`ALLOWED_PROJECTS` env var derived from
+  `var.project_caps`) so a forged or stale budget can't cause a kill on a project
+  that isn't explicitly managed by this Terraform.
+- **Caps are per-project, not billing-account-wide.** Limits blast radius — one
+  runaway project can't take down the production blog.
+- **Staging sub-cap live canary before Phase 2.** Rather than a synthetic-payload
+  dry-run of the kill path, the first real end-to-end test is done by applying a
+  deliberately-too-low cap to `blog-towles-staging` (a project whose brief
+  billing-disable is recoverable), observing the real budget → Pub/Sub → function →
+  `updateBillingInfo` path, re-enabling, and then applying the correct caps to all
+  projects. This exercises every IAM grant that a synthetic publish skips.
+
+## Open Questions
+
+### Resolved During Planning
+
+- *Which project hosts the infra?* `blog-towles-production`. Reuses existing TF state
+  bucket `blog-towles-production-tfstate` with prefix `terraform/gcp-billing`.
+- *BigQuery export cost at personal scale?* Effectively free. Storage ≪ 100 MB/year;
+  queries within 1 TB/month free tier.
+- *Run external research?* No — Google's pattern is canonical and already encoded in
+  the code.
+- *Should Phase 1 include a live trip test?* No. Dry-run only until Phase 2 caps are
+  armed. A live trip is Unit 6 and optional.
+
+### Deferred to Implementation
+
+- **Actual cap values per project.** Will be determined by Unit 4's analysis of BQ
+  data. The rough heuristic is `max(2 × observed monthly baseline, $10 floor)`, but
+  the concrete numbers require the data.
+- **Whether to drop `gen-lang-client-0238175572` from the billing account.** This
+  project's origin is unclear (likely auto-provisioned by a Google service); it may
+  be safer to unlink it than to give it a cap. Inspect in Unit 4.
+- **Whether the detailed usage cost export is needed.** Unit 2 enables standard usage
+  cost; detailed (per-SKU) is a second toggle. Decision deferred until Unit 4 shows
+  whether per-SKU breakdown is needed to understand spend.
+- **Exact terraform provider version after apply.** `terraform validate` already
+  passed against hashicorp/google 5.45.2; a real `init` may pick up a newer patch
+  version. If so, commit the resulting `.terraform.lock.hcl`.
+- **Exact sub-cap value for the staging canary in Unit 5.** Will be set to a value
+  definitely below current MTD spend on `blog-towles-staging` (based on BQ data from
+  Unit 4). Goal is immediate trip on next budget evaluation.
+
+## High-Level Technical Design
+
+> *This illustrates the intended rollout sequence and is directional guidance for review,
+> not implementation specification.*
+
+```mermaid
+flowchart TD
+    A[Unit 1: Phase 1 apply<br/>infra + dataset, empty caps] --> B[Unit 2: Console enable<br/>BQ billing export]
+    A --> C[Unit 3: Dry-run smoke test<br/>plumbing only]
+    B -->|~24h| D[Data landing in BQ]
+    D -->|7-14 days| E[Unit 4: Baseline analysis<br/>+ cap sizing]
+    E --> F[Unit 5: Staging sub-cap canary<br/>real trip on staging]
+    F -->|trip observed<br/>+ re-enable| G[Unit 6: Phase 2 apply<br/>all caps armed]
+    G --> H[Rollout complete]
+
+    style A fill:#e8f4ff,stroke:#2b7cd6
+    style F fill:#ffe0b2,stroke:#e65100
+    style G fill:#fff3e0,stroke:#f57c00
+```
+
+## Implementation Units
+
+- [x] **Unit 1: Phase 1 apply — provision infra with empty `project_caps`** ✅ applied 2026-04-14
+
+    **Post-apply correction:** the two `*_iam_member` resources granting IAM to Google-managed
+    service agents (`gcp-sa-billing-bq-exp` and `gcp-sa-billingbudgets`) were **removed from
+    the Terraform** after the first apply failed with "Service account ... does not exist".
+    These agents are provisioned lazily by Google on first use of the corresponding service
+    (BQ billing export in Unit 2; first budget creation in Unit 5). Google auto-grants the
+    required roles at that time, so the removed bindings were redundant as well as
+    prematurely-referenced. Final resource count: 20 created (originally planned 22).
+
+
+**Goal:** Apply `infra/gcp-billing/` against billing account `015529-D0D3BB-5BEDEE` so
+that the Pub/Sub topic, runtime service account, IAM bindings, Cloud Function, and
+BigQuery dataset exist. No budgets yet — `project_caps = {}` means zero
+`google_billing_budget` resources are created.
+
+**Requirements:** R1
+
+**Dependencies:**
+- The applying identity must be a **user account** (not a CI service account — existing CI
+  SAs almost certainly lack `roles/billing.admin`) with:
+  - `roles/billing.admin` on billing account `015529-D0D3BB-5BEDEE` (needed to grant
+    `roles/billing.projectManager` to the function SA via
+    `google_billing_account_iam_member`, and to create budgets in Unit 5)
+  - `roles/editor` or equivalent resource-creation roles on `blog-towles-production`
+- `gcloud auth application-default login` active for that identity.
+- Precondition: `gcloud billing budgets list --billing-account=015529-D0D3BB-5BEDEE`
+  returns no entries starting with `spend-cap-` (avoids display-name collisions with
+  manually-created budgets that would cause the function to double-fire or target the
+  wrong project).
+
+**Files:**
+- Modify: `infra/gcp-billing/terraform.tfvars` (confirm `project_caps = {}`)
+- Artifacts (not committed): `.terraform/`, `.terraform.lock.hcl`, `function.zip`
+
+**Approach:**
+- Run `terraform init -backend-config=backend.tfvars` (first-time init against the
+  GCS backend at `gs://blog-towles-production-tfstate/terraform/gcp-billing/`).
+- Run `terraform plan -var-file=terraform.tfvars`. Expect:
+  - ~10 `google_project_service` resources
+  - 1 `google_pubsub_topic`
+  - 1 `google_service_account`
+  - 1 `google_billing_account_iam_member`
+  - 3 `google_project_iam_member`
+  - 1 `google_storage_bucket` + 1 `google_storage_bucket_object`
+  - 1 `google_bigquery_dataset` + 1 `google_bigquery_dataset_iam_member`
+  - 1 `google_cloudfunctions2_function`
+  - 0 `google_billing_budget`
+- Review the plan; apply if clean.
+- Commit `.terraform.lock.hcl` so CI or future applies get the same provider versions.
+
+**Patterns to follow:**
+- `infra/terraform/modules/cost-scheduler/main.tf` — same `archive_file` + GCS object
+  + `google_cloudfunctions2_function` layout, already known to apply cleanly.
+
+**Test scenarios:**
+- *Happy path:* `terraform apply` exits 0, `terraform state list` shows all expected
+  resources, no `google_billing_budget.*` entries present.
+- *Error path — billing account IAM missing:* if the applying identity lacks
+  `roles/billing.admin`, the `google_billing_account_iam_member` resource fails with
+  a permission error. Expected, recoverable.
+- *Error path — API not yet propagated:* first-time API enablement can take 1–2 min
+  to propagate; a retry of `apply` after the propagation error should succeed.
+
+**Verification:**
+- `gcloud pubsub topics describe billing-cap-alerts --project=blog-towles-production`
+  returns a topic.
+- `gcloud functions describe billing-kill-switch --gen2 --region=us-central1
+  --project=blog-towles-production` returns `ACTIVE` state.
+- `gcloud iam service-accounts list --project=blog-towles-production` includes
+  `billing-kill-switch@…`.
+- `bq ls --project_id=blog-towles-production` shows `billing_export`.
+
+---
+
+- [x] **Unit 2: Enable BigQuery billing export in the Billing Console** ✅ enabled 2026-04-14
+
+    **Note for future reference:** the actual billing-export service agent granted access
+    when enabling Standard usage cost export was `billing-export-bigquery@system.gserviceaccount.com`
+    (the legacy format), not the `@gcp-sa-billing-bq-exp.iam.gserviceaccount.com` format
+    my original Terraform assumed. Confirming IAM auto-grant happens regardless — no manual
+    IAM step needed.
+
+
+**Goal:** Start data flowing from billing account `015529-D0D3BB-5BEDEE` into
+`blog-towles-production.billing_export`. This cannot be done via Terraform.
+
+**Requirements:** R2
+
+**Dependencies:** Unit 1 (dataset must exist).
+
+**Files:** None — console-only change.
+
+**Approach:**
+- Navigate to
+  <https://console.cloud.google.com/billing/015529-D0D3BB-5BEDEE/export>.
+- Under *BigQuery export* → *Standard usage cost* → *Edit settings*:
+  - Project: `blog-towles-production`
+  - Dataset: `billing_export`
+  - Save.
+- Decide on *Detailed usage cost* export (per-SKU granularity). Default: skip for now,
+  revisit in Unit 4 if needed.
+- Skip *Pricing* export (not useful for spend caps).
+
+**Test scenarios:**
+- *Happy path:* ~24h after save, `bq ls blog-towles-production:billing_export` lists
+  a table named `gcp_billing_export_v1_015529_D0D3BB_5BEDEE`.
+- *Error path — IAM missing:* if the billing-export service agent
+  (`service-<project_number>@gcp-sa-billing-bq-exp.iam.gserviceaccount.com`) wasn't
+  granted `roles/bigquery.dataEditor` on the dataset, the console save will fail with
+  a permission error. Unit 1's `google_bigquery_dataset_iam_member` should have
+  handled this — if it didn't, re-check the grant.
+- *Edge case — service agent not yet provisioned:* the billing-export service agent
+  is typically created by Google the first time BQ export is configured on a billing
+  account. Unit 1's `google_bigquery_dataset_iam_member` does not validate principals,
+  so the grant is accepted regardless. After the console save in Unit 2, re-check the
+  IAM binding still references the now-existing agent; if the console recreated or
+  relocated the agent, `terraform apply` again to refresh the binding.
+
+**Verification:**
+- Console shows the export as *Configured* with the correct project/dataset.
+- After 24h, a trivial BQ query returns rows:
+  ```sql
+  SELECT COUNT(*) AS row_count, MAX(usage_start_time) AS latest
+  FROM `blog-towles-production.billing_export.gcp_billing_export_v1_015529_D0D3BB_5BEDEE`;
+  ```
+
+---
+
+- [x] **Unit 3: Smoke-test the kill-switch with a dry-run publish** ✅ passed 2026-04-14
+
+    **Note for future reference:** the initial function deploy used a bare
+    `exports.killSwitch = (cloudEvent) => {...}` export, which the Functions
+    Framework interpreted as a 1st-gen background signature — causing every invocation
+    to log "No Pub/Sub message payload; ignoring" because `cloudEvent.data.message.data`
+    was undefined under that shape. Fix: added `@google-cloud/functions-framework` as
+    a dependency and switched to explicit CloudEvent registration via
+    `functions.cloudEvent('killSwitch', async (cloudEvent) => {...})`. All 4 test
+    scenarios (dry-run, missing fields, below-cap, allowlist-reject) pass after
+    redeploy. Zero UpdateBillingInfo audit events, confirming guards are tight.
+
+
+**Goal:** Verify the full path — Pub/Sub → Eventarc → Cloud Run function invocation
+→ Cloud Logging — works end-to-end before any real budget is wired up. Use a payload
+whose `budgetDisplayName` does not start with `spend-cap-` so the function
+log-and-exits without touching billing.
+
+**Requirements:** R6
+
+**Dependencies:** Unit 1.
+
+**Files:** None — runtime verification only.
+
+**Approach:**
+- Publish a synthetic payload via `gcloud pubsub topics publish billing-cap-alerts
+  --project=blog-towles-production --message='{"budgetDisplayName":"dry-run",…}'`
+  (exact command in `infra/gcp-billing/README.md`).
+- Immediately tail the function logs:
+  `gcloud functions logs read billing-kill-switch --gen2 --region=us-central1
+  --project=blog-towles-production --limit=50`.
+- Expect a log line containing `Ignoring: budgetDisplayName "dry-run" does not match
+  spend-cap-<project>`.
+
+**Test scenarios:**
+- *Happy path — dry-run message:* `budgetDisplayName: "dry-run"` → function logs
+  "Ignoring…" and exits.
+- *Edge case — missing costAmount/budgetAmount:* payload with only `budgetDisplayName`
+  set → function logs "costAmount/budgetAmount missing or non-numeric" and exits.
+- *Edge case — below-threshold payload:* `budgetDisplayName: "spend-cap-fake-project"`,
+  `costAmount: 1`, `budgetAmount: 100` → function logs "Below cap (cost=1 <
+  budget=100); no action" and exits. Proves the threshold guard works without
+  requiring a real project.
+
+**Verification:**
+- All three log messages appear in Cloud Logging.
+- Function execution metrics show 3 successful invocations, 0 errors.
+- No `cloudbilling.googleapis.com` audit log entries for `UpdateBillingInfo` (the
+  function never called it).
+
+---
+
+- [ ] **Unit 4: Observation window + baseline analysis + cap sizing**
+
+**Goal:** After 7–14 days of BQ export data, compute a per-project monthly spend
+baseline and pick cap values with enough headroom to avoid tripping under normal load.
+
+**Requirements:** R3, R4, R5
+
+**Dependencies:** Unit 2 (export must be landing data ≥ 7 days).
+
+**Files:**
+- Modify: `infra/gcp-billing/terraform.tfvars` (fill in `project_caps` map)
+- Create (optional, not committed): a scratch notes file with the BQ query output
+  for future reference
+
+**Approach:**
+- Run a per-project rollup query against
+  `blog-towles-production.billing_export.gcp_billing_export_v1_015529_D0D3BB_5BEDEE`:
+  ```sql
+  SELECT project.id AS project_id,
+         SUM(cost) AS mtd_cost,
+         SUM(cost) / DATE_DIFF(CURRENT_DATE(), DATE(MIN(usage_start_time)), DAY)
+           * 30 AS projected_monthly
+  FROM `blog-towles-production.billing_export.gcp_billing_export_v1_015529_D0D3BB_5BEDEE`
+  WHERE invoice.month = FORMAT_DATE('%Y%m', CURRENT_DATE())
+  GROUP BY project.id
+  ORDER BY mtd_cost DESC;
+  ```
+- For each project, compute cap as `max(ceil(2 × projected_monthly), floor)` where
+  `floor` is:
+  - `$50` for `blog-towles-production` (can't let this trip on normal traffic)
+  - `$15` for `blog-towles-staging` (auto-sleeps overnight via cost-scheduler)
+  - `$10` for all other projects (personal/experimental)
+- Inspect `gen-lang-client-0238175572` spend specifically. If ~$0 and origin is
+  unknown, consider asking the user to unlink it from the billing account entirely
+  instead of giving it a cap.
+- If any project projects above its floor, use `ceil(2 × projected_monthly)`.
+- Round caps to tidy integers (USD units must be integers per `google_billing_budget`
+  amount spec anyway).
+- Commit the updated `terraform.tfvars`.
+
+**Test scenarios:** — *Test expectation: none — this is an analysis and configuration
+unit with no behavioral change. Verification is the baseline documentation + tfvars
+diff.*
+
+**Verification:**
+- Every project on billing account `015529-D0D3BB-5BEDEE` appears as a key in
+  `project_caps` (enforce R4: no gaps).
+- Every cap value is ≥ 2× observed projected monthly spend, floored at the per-tier
+  minimum.
+- `terraform plan -var-file=terraform.tfvars` shows N creations of
+  `google_billing_budget.project_cap["<project>"]` where N = number of projects on
+  the billing account.
+
+---
+
+- [ ] **Unit 5: Staging sub-cap live canary — mandatory IAM + end-to-end validation**
+
+**Goal:** Prove the full real path — a real Cloud Billing budget firing a real
+threshold notification through real Pub/Sub → real function → real
+`updateBillingInfo` — before arming caps on every project. Uses `blog-towles-staging`
+because its billing being briefly disabled is recoverable (no user-facing traffic,
+Cloud SQL data persists across billing-disable, cost-scheduler auto-sleep limits
+ongoing spend anyway).
+
+**Requirements:** R6 end-to-end (Unit 3 only tested the plumbing; this tests the
+`updateBillingInfo` IAM path that Unit 3 deliberately skipped), R7.
+
+**Dependencies:** Unit 4 (baseline MTD spend for staging must be known so the
+canary cap is set below it).
+
+**Files:**
+- Modify: `infra/gcp-billing/terraform.tfvars` — temporarily set
+  `project_caps = { "blog-towles-staging" = <N> }` where N is clearly below staging's
+  current MTD spend. All other projects remain absent from the map for this step.
+
+**Approach:**
+- Confirm staging's current MTD spend from the BQ query in Unit 4 (e.g., if MTD is
+  $3.50, set cap to `1`).
+- `terraform apply -var-file=terraform.tfvars` — creates only the staging budget
+  plus a function redeploy (the `ALLOWED_PROJECTS` env var changes to include
+  `blog-towles-staging`).
+- Wait for the next budget evaluation cycle. **This may take 1–24 hours** given
+  known budget notification lag — do not interpret a delayed trip as a failure.
+- Observe in order:
+  - Budget notification published to topic (visible in Pub/Sub subscription metrics
+    or `gcloud pubsub` read).
+  - Cloud Function logs show: `"Disabling billing on blog-towles-staging (cost=X >=
+    budget=<N>)"`.
+  - `gcloud billing projects describe blog-towles-staging` returns
+    `billingEnabled: false`.
+  - Cloud SQL instance in staging is unreachable; Cloud Run staging service returns
+    errors.
+- Re-enable:
+  ```
+  gcloud billing projects link blog-towles-staging \
+    --billing-account=015529-D0D3BB-5BEDEE
+  ```
+  Confirm `billingEnabled: true`. Cloud SQL + Cloud Run recover.
+- **Idempotency check:** while billing is disabled (before re-enable), the budget
+  may continue firing at subsequent evaluation cycles. Confirm the function logs
+  `"Billing already disabled on blog-towles-staging; exiting idempotently"` for each
+  subsequent invocation and does not re-call `updateBillingInfo`.
+- Reset `terraform.tfvars` back to the full correct caps from Unit 4 (staging's
+  real cap, not $1).
+
+**Patterns to follow:**
+- The existing `cost-scheduler` module in `infra/terraform/modules/cost-scheduler/`
+  already uses `google_cloudfunctions2_function` and a Pub/Sub-adjacent trigger
+  pattern; this unit's reasoning about re-enable and Cloud SQL recovery is informed
+  by that module's operational behavior.
+
+**Test scenarios:**
+- *Happy path — real over-cap trip:* budget with `specified_amount < MTD cost` fires
+  within 1–24h, function disables billing on staging, `billingEnabled: false`.
+- *Edge case — idempotent retrips:* subsequent budget evaluations during the
+  billing-disabled window invoke the function; it log-and-exits without duplicate
+  `updateBillingInfo` calls. Proves the `getBillingInfo` idempotency guard works
+  with real API responses.
+- *Error path — IAM insufficient (diagnostic):* if `roles/billing.admin` on the
+  function SA is somehow not fully propagated, the function errors on
+  `updateBillingInfo` with PERMISSION_DENIED and `RETRY_POLICY_RETRY` re-invokes.
+  Cloud Logging shows the error. Expected diagnostic outcome — do NOT proceed to
+  Unit 6 until this test passes cleanly.
+- *Edge case — ALLOWED_PROJECTS allowlist:* verify by publishing a synthetic payload
+  with `budgetDisplayName: "spend-cap-jarvis-home-487516"` *before* Unit 6 arms
+  jarvis's cap. The allowlist contains only `blog-towles-staging` at this point, so
+  the function must log `"Refusing: projectId \"jarvis-home-487516\" not in
+  ALLOWED_PROJECTS allowlist"` and exit. Proves the forged-trip defense.
+
+**Verification:**
+- `gcloud billing projects describe blog-towles-staging` showed `billingEnabled:
+  false` during the window, then `true` after re-link.
+- Cloud Audit Logs show exactly one successful `UpdateBillingInfo` call for the
+  staging project during the window; subsequent retrips did not re-call it.
+- Staging site/services recovered without data loss after re-enable.
+- Synthetic forged-trip payload was rejected by the allowlist.
+
+---
+
+- [ ] **Unit 6: Phase 2 apply — arm caps on all remaining projects**
+
+**Goal:** Apply the correct cap map from Unit 4 to every project on the billing
+account. Budgets become visible in the Billing Console; threshold crossings will
+publish to the Pub/Sub topic; kill-switch will fire on a 100% crossing.
+
+**Requirements:** R4, R5
+
+**Dependencies:** Unit 5 must have passed cleanly (real IAM path proven).
+
+**Files:**
+- Modify: `infra/gcp-billing/terraform.tfvars` — set the full `project_caps` map
+  from Unit 4 (not the sub-$1 staging-only map from Unit 5).
+
+**Approach:**
+- `terraform plan -var-file=terraform.tfvars` — verify:
+  - Staging budget updates in place (from $1 back to its real cap).
+  - All other project budgets are created.
+  - Function is updated in-place to reflect the expanded `ALLOWED_PROJECTS` env var.
+  - No unexpected destructions.
+- `terraform apply -var-file=terraform.tfvars`.
+- Eyeball the Billing Console budget list to confirm every project has its cap
+  present and threshold rules at 50/90/100%.
+
+**Patterns to follow:**
+- Same apply procedure as Unit 1, with the full caps map.
+
+**Test scenarios:**
+- *Happy path:* `apply` exits 0. N−1 budget creations (all projects except staging)
+  + 1 budget update (staging: $1 → real cap) + 1 function update-in-place (for
+  `ALLOWED_PROJECTS` env var).
+- *Error path — project-number lookup fails:* if `data.google_project.capped[<id>]`
+  can't resolve (project renamed or removed between tfvars edit and apply), apply
+  fails at plan time. Expected and safe — correct the tfvars and retry.
+- *Integration:* After apply,
+  `gcloud billing budgets list --billing-account=015529-D0D3BB-5BEDEE` shows N
+  budgets, each with `displayName` matching `spend-cap-<project_id>`.
+- *R4 coverage check:* the set difference
+  `gcloud billing projects list --billing-account=015529-D0D3BB-5BEDEE
+   --format='value(projectId)'` minus `keys(var.project_caps)` is empty. Any project
+  on the billing account without a cap is an R4 violation.
+
+**Verification:**
+- Every project listed by
+  `gcloud billing projects list --billing-account=015529-D0D3BB-5BEDEE` has a
+  corresponding budget (R4 coverage check, above).
+- Each budget's `allUpdatesRule.pubsubTopic` points at
+  `projects/blog-towles-production/topics/billing-cap-alerts`.
+- Terraform state contains exactly N `google_billing_budget.project_cap` entries.
+- Function's deployed `ALLOWED_PROJECTS` env var contains every project_id (not just
+  staging). Verify via `gcloud functions describe billing-kill-switch --gen2
+  --region=us-central1 --project=blog-towles-production
+  --format='value(serviceConfig.environmentVariables.ALLOWED_PROJECTS)'`.
+
+## System-Wide Impact
+
+- **Interaction graph:** `google_billing_budget` resources → Pub/Sub topic
+  `billing-cap-alerts` → Eventarc trigger → Cloud Function `billing-kill-switch` →
+  `cloudbilling.googleapis.com/v1/projects.updateBillingInfo`. Any service on any of
+  the 6 projects is downstream of a successful trip (billing-off → Cloud Run /
+  Cloud SQL / storage egress all start failing within minutes).
+- **Error propagation:** Function errors retry per `RETRY_POLICY_RETRY` on the event
+  trigger. A runaway bug in the function would retry publishes repeatedly; budget
+  events are low volume (a few per day max), so retry-storm risk is negligible.
+- **State lifecycle risks:** A budget-triggered disable leaves the project in a
+  "billing-disabled but resources still exist" state until manually re-enabled.
+  Cloud SQL instances, Cloud Run services, GCS buckets don't get deleted — just
+  deactivated. Re-link restores service.
+- **API surface parity:** Not applicable — this is net-new infra with no existing
+  API surface.
+- **Integration coverage:** Unit 3 (dry-run) and Unit 6 (live trip) provide the
+  cross-layer integration coverage that unit tests alone couldn't prove. Pub/Sub
+  trigger wiring, Eventarc SA token creation, and function SA billing-IAM are all
+  only exercised at runtime.
+- **Unchanged invariants:** The existing `infra/terraform/` stacks (prod + staging
+  Cloud Run) are untouched. State bucket `blog-towles-production-tfstate` is shared
+  but uses a distinct prefix (`terraform/gcp-billing` vs. `terraform/state`); no
+  collision risk.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| **Budget-notification latency (4–24h) means spend can burn past cap before trip fires.** | Documented as a Known Limitation in Problem Frame. Cap sizing in Unit 4 should price in worst-case 1-day burn rate, not treat the cap as a real-time ceiling. Per-service preventive quotas (deferred to a separate task) are the complementary mechanism for real-time spend bounding. |
+| **Host project (`blog-towles-production`) self-kill takes the kill-switch offline.** | Accepted limitation: the in-flight kill completes synchronously before the function's own billing is disabled, so the trip itself isn't lost. Other projects are temporarily unprotected from *new* trips until the host is re-linked. Mitigation = keep prod's cap high enough that it rarely trips, and monitor the billing-admin email that fires on any trip. |
+| **A cap set too low trips the production blog.** | Unit 4 enforces `≥ 2× observed baseline` and a `$50` floor for `blog-towles-production`. If uncertain, err higher — the cap can always be lowered later. |
+| **BigQuery export never starts landing data.** | Unit 2 explicitly depends on the dataset-IAM grant from Unit 1. Verification query in Unit 2 checks for data within 24h. If absent, first place to check is the billing-export SA's `bigquery.dataEditor` grant on the dataset. |
+| **IAM insufficient or unpropagated when first real trip fires.** | Using `roles/billing.admin` (not the narrower `roles/billing.projectManager`) eliminates role-sufficiency uncertainty. Unit 5's staging sub-cap canary is mandatory and exercises the real `updateBillingInfo` IAM path end-to-end before Unit 6 arms any remaining caps. |
+| **Forged Pub/Sub message from an identity with project-level `roles/editor` could disable billing on an unrelated project.** | Function enforces an `ALLOWED_PROJECTS` allowlist derived from `var.project_caps`; any projectId not in the allowlist is rejected and logged. Topic-level IAM additionally grants publish only to the billing-budgets service agent (defense in depth; project-level IAM can still inherit publish). |
+| **Billing-admin email notifications are the only human signal of a trip.** | Acceptable for v1; default IAM recipients are enabled in `budgets.tf`. Notification upgrade (Slack/pager) is explicitly deferred. |
+| **`gen-lang-client-0238175572` is auto-provisioned by a Google service and can't be unlinked.** | Unit 4 inspects this specifically. Fallback: give it a minimal cap ($10) like any other project. |
+| **Provider version drift between `validate` time and real `apply` time.** | Commit `.terraform.lock.hcl` after Unit 1's `init` so subsequent applies are pinned. |
+| **Applying user's identity lacks `roles/billing.admin` on the billing account.** | Plan fails at `google_billing_account_iam_member` with a clear error. User elevates permissions and retries — no partial state because the resource hadn't been created yet. |
+| **Budget manually edited or deleted in the Billing Console** (e.g., display name changed, breaking the `spend-cap-<project_id>` convention) **causes silent Terraform drift.** | Accepted. Re-running `terraform apply` on this stack restores the intended state. No scheduled drift detection is configured. |
+
+## Documentation / Operational Notes
+
+- `infra/gcp-billing/README.md` already contains the apply commands, console-enable
+  URL, synthetic-publish test payload, and re-enable command. It's the canonical
+  operational doc — this plan complements it by sequencing the rollout and adding
+  cap-sizing methodology.
+- After Unit 4, consider leaving a comment in `terraform.tfvars` documenting the
+  date and methodology of the cap numbers (e.g., `# Caps set 2026-04-28 from 14-day
+  baseline; see docs/plans/2026-04-14-001 for method`).
+- No runbook, no on-call impact — this is a defensive kill-switch for a personal
+  billing account, not a production service.
+
+## Sources & References
+
+- `infra/gcp-billing/` — the Terraform stack being rolled out
+- `infra/gcp-billing/README.md` — operational playbook (commands, URLs, payloads)
+- `infra/terraform/modules/cost-scheduler/` — prior-art Cloud Function module the
+  new stack mirrors
+- <https://cloud.google.com/billing/docs/how-to/notify#cap_disable_billing> — GCP
+  canonical pattern
+- <https://cloud.google.com/billing/docs/how-to/export-data-bigquery-setup> —
+  manual BQ export enablement
+- Previous session (2026-04-14): authored `infra/gcp-billing/`, passed
+  `terraform validate` against hashicorp/google 5.45.2

--- a/docs/plans/2026-04-14-001-feat-gcp-billing-killswitch-rollout-plan.md
+++ b/docs/plans/2026-04-14-001-feat-gcp-billing-killswitch-rollout-plan.md
@@ -591,7 +591,7 @@ publish to the Pub/Sub topic; kill-switch will fire on a 100% crossing.
   budgets, each with `displayName` matching `spend-cap-<project_id>`.
 - _R4 coverage check:_ the set difference
   `gcloud billing projects list --billing-account=015529-D0D3BB-5BEDEE
- --format='value(projectId)'` minus `keys(var.project_caps)` is empty. Any project
+--format='value(projectId)'` minus `keys(var.project_caps)` is empty. Any project
   on the billing account without a cap is an R4 violation.
 
 **Verification:**

--- a/docs/plans/2026-04-14-001-feat-gcp-billing-killswitch-rollout-plan.md
+++ b/docs/plans/2026-04-14-001-feat-gcp-billing-killswitch-rollout-plan.md
@@ -1,5 +1,5 @@
 ---
-title: "feat: Roll out GCP billing kill-switch + BigQuery export"
+title: 'feat: Roll out GCP billing kill-switch + BigQuery export'
 type: feat
 status: active
 date: 2026-04-14
@@ -23,7 +23,7 @@ GCP has no native hard spend cap. All six projects under billing account
 `015529-D0D3BB-5BEDEE` — including personal experiments like `jarvis-home-487516` —
 are currently exposed to unbounded spend if something goes wrong (runaway Cloud Run
 instances, buggy Cloud SQL query loops, API abuse). The stack built during the
-previous session implements Google's canonical pattern for a *reactive* kill-switch
+previous session implements Google's canonical pattern for a _reactive_ kill-switch
 (budget → Pub/Sub → function → `updateBillingInfo`). This plan is about safely putting
 it into operation without guessing at cap values that could trip under normal load.
 
@@ -39,13 +39,13 @@ it into operation without guessing at cap values that could trip under normal lo
 - **Preventive quotas are a separate, complementary mechanism** — not a replacement.
   Cloud Run `max_instances`, Cloud SQL tier limits, per-API quotas, and organization
   policies constrain resource creation in real time. They're out of scope here but
-  worth considering as a follow-up layer; the right overall design is *quotas for
-  prevention + kill-switch for the long tail*.
+  worth considering as a follow-up layer; the right overall design is _quotas for
+  prevention + kill-switch for the long tail_.
 - **Self-kill is acceptable.** If `blog-towles-production` (the host project) trips
   its own cap, the function calls `updateBillingInfo` synchronously before its own
   billing is disabled, so the kill itself completes. After that, the Pub/Sub topic
   and function go offline until the host is manually re-linked — meaning other
-  projects are temporarily unprotected from *new* trips. Accepted on the basis that
+  projects are temporarily unprotected from _new_ trips. Accepted on the basis that
   (a) trips are rare, (b) if prod blew its cap you have bigger problems and will
   notice, (c) the alternative (a dedicated admin project) is heavier than the risk
   warrants for a personal-scale setup.
@@ -116,7 +116,7 @@ context:
 - **Billing export cannot be provisioned by Terraform.** The google provider has no
   resource for `billingAccounts.updateBillingExport`. Dataset + IAM via TF; enable via
   console. This is why Unit 2 exists as a standalone manual step.
-- **`budget_filter.projects` requires project *numbers*, not IDs.** `budgets.tf`
+- **`budget_filter.projects` requires project _numbers_, not IDs.** `budgets.tf`
   already handles this via `data "google_project"` lookup — worth flagging if any of
   the 6 projects fail to resolve.
 - **`roles/billing.projectManager` on the billing account (not a project) is the
@@ -162,13 +162,13 @@ context:
 
 ### Resolved During Planning
 
-- *Which project hosts the infra?* `blog-towles-production`. Reuses existing TF state
+- _Which project hosts the infra?_ `blog-towles-production`. Reuses existing TF state
   bucket `blog-towles-production-tfstate` with prefix `terraform/gcp-billing`.
-- *BigQuery export cost at personal scale?* Effectively free. Storage ≪ 100 MB/year;
+- _BigQuery export cost at personal scale?_ Effectively free. Storage ≪ 100 MB/year;
   queries within 1 TB/month free tier.
-- *Run external research?* No — Google's pattern is canonical and already encoded in
+- _Run external research?_ No — Google's pattern is canonical and already encoded in
   the code.
-- *Should Phase 1 include a live trip test?* No. Dry-run only until Phase 2 caps are
+- _Should Phase 1 include a live trip test?_ No. Dry-run only until Phase 2 caps are
   armed. A live trip is Unit 6 and optional.
 
 ### Deferred to Implementation
@@ -191,8 +191,8 @@ context:
 
 ## High-Level Technical Design
 
-> *This illustrates the intended rollout sequence and is directional guidance for review,
-> not implementation specification.*
+> _This illustrates the intended rollout sequence and is directional guidance for review,
+> not implementation specification._
 
 ```mermaid
 flowchart TD
@@ -213,14 +213,13 @@ flowchart TD
 
 - [x] **Unit 1: Phase 1 apply — provision infra with empty `project_caps`** ✅ applied 2026-04-14
 
-    **Post-apply correction:** the two `*_iam_member` resources granting IAM to Google-managed
-    service agents (`gcp-sa-billing-bq-exp` and `gcp-sa-billingbudgets`) were **removed from
-    the Terraform** after the first apply failed with "Service account ... does not exist".
-    These agents are provisioned lazily by Google on first use of the corresponding service
-    (BQ billing export in Unit 2; first budget creation in Unit 5). Google auto-grants the
-    required roles at that time, so the removed bindings were redundant as well as
-    prematurely-referenced. Final resource count: 20 created (originally planned 22).
-
+  **Post-apply correction:** the two `*_iam_member` resources granting IAM to Google-managed
+  service agents (`gcp-sa-billing-bq-exp` and `gcp-sa-billingbudgets`) were **removed from
+  the Terraform** after the first apply failed with "Service account ... does not exist".
+  These agents are provisioned lazily by Google on first use of the corresponding service
+  (BQ billing export in Unit 2; first budget creation in Unit 5). Google auto-grants the
+  required roles at that time, so the removed bindings were redundant as well as
+  prematurely-referenced. Final resource count: 20 created (originally planned 22).
 
 **Goal:** Apply `infra/gcp-billing/` against billing account `015529-D0D3BB-5BEDEE` so
 that the Pub/Sub topic, runtime service account, IAM bindings, Cloud Function, and
@@ -230,6 +229,7 @@ BigQuery dataset exist. No budgets yet — `project_caps = {}` means zero
 **Requirements:** R1
 
 **Dependencies:**
+
 - The applying identity must be a **user account** (not a CI service account — existing CI
   SAs almost certainly lack `roles/billing.admin`) with:
   - `roles/billing.admin` on billing account `015529-D0D3BB-5BEDEE` (needed to grant
@@ -243,10 +243,12 @@ BigQuery dataset exist. No budgets yet — `project_caps = {}` means zero
   wrong project).
 
 **Files:**
+
 - Modify: `infra/gcp-billing/terraform.tfvars` (confirm `project_caps = {}`)
 - Artifacts (not committed): `.terraform/`, `.terraform.lock.hcl`, `function.zip`
 
 **Approach:**
+
 - Run `terraform init -backend-config=backend.tfvars` (first-time init against the
   GCS backend at `gs://blog-towles-production-tfstate/terraform/gcp-billing/`).
 - Run `terraform plan -var-file=terraform.tfvars`. Expect:
@@ -263,23 +265,26 @@ BigQuery dataset exist. No budgets yet — `project_caps = {}` means zero
 - Commit `.terraform.lock.hcl` so CI or future applies get the same provider versions.
 
 **Patterns to follow:**
+
 - `infra/terraform/modules/cost-scheduler/main.tf` — same `archive_file` + GCS object
-  + `google_cloudfunctions2_function` layout, already known to apply cleanly.
+  - `google_cloudfunctions2_function` layout, already known to apply cleanly.
 
 **Test scenarios:**
-- *Happy path:* `terraform apply` exits 0, `terraform state list` shows all expected
+
+- _Happy path:_ `terraform apply` exits 0, `terraform state list` shows all expected
   resources, no `google_billing_budget.*` entries present.
-- *Error path — billing account IAM missing:* if the applying identity lacks
+- _Error path — billing account IAM missing:_ if the applying identity lacks
   `roles/billing.admin`, the `google_billing_account_iam_member` resource fails with
   a permission error. Expected, recoverable.
-- *Error path — API not yet propagated:* first-time API enablement can take 1–2 min
+- _Error path — API not yet propagated:_ first-time API enablement can take 1–2 min
   to propagate; a retry of `apply` after the propagation error should succeed.
 
 **Verification:**
+
 - `gcloud pubsub topics describe billing-cap-alerts --project=blog-towles-production`
   returns a topic.
 - `gcloud functions describe billing-kill-switch --gen2 --region=us-central1
-  --project=blog-towles-production` returns `ACTIVE` state.
+--project=blog-towles-production` returns `ACTIVE` state.
 - `gcloud iam service-accounts list --project=blog-towles-production` includes
   `billing-kill-switch@…`.
 - `bq ls --project_id=blog-towles-production` shows `billing_export`.
@@ -288,12 +293,11 @@ BigQuery dataset exist. No budgets yet — `project_caps = {}` means zero
 
 - [x] **Unit 2: Enable BigQuery billing export in the Billing Console** ✅ enabled 2026-04-14
 
-    **Note for future reference:** the actual billing-export service agent granted access
-    when enabling Standard usage cost export was `billing-export-bigquery@system.gserviceaccount.com`
-    (the legacy format), not the `@gcp-sa-billing-bq-exp.iam.gserviceaccount.com` format
-    my original Terraform assumed. Confirming IAM auto-grant happens regardless — no manual
-    IAM step needed.
-
+  **Note for future reference:** the actual billing-export service agent granted access
+  when enabling Standard usage cost export was `billing-export-bigquery@system.gserviceaccount.com`
+  (the legacy format), not the `@gcp-sa-billing-bq-exp.iam.gserviceaccount.com` format
+  my original Terraform assumed. Confirming IAM auto-grant happens regardless — no manual
+  IAM step needed.
 
 **Goal:** Start data flowing from billing account `015529-D0D3BB-5BEDEE` into
 `blog-towles-production.billing_export`. This cannot be done via Terraform.
@@ -305,25 +309,27 @@ BigQuery dataset exist. No budgets yet — `project_caps = {}` means zero
 **Files:** None — console-only change.
 
 **Approach:**
+
 - Navigate to
   <https://console.cloud.google.com/billing/015529-D0D3BB-5BEDEE/export>.
-- Under *BigQuery export* → *Standard usage cost* → *Edit settings*:
+- Under _BigQuery export_ → _Standard usage cost_ → _Edit settings_:
   - Project: `blog-towles-production`
   - Dataset: `billing_export`
   - Save.
-- Decide on *Detailed usage cost* export (per-SKU granularity). Default: skip for now,
+- Decide on _Detailed usage cost_ export (per-SKU granularity). Default: skip for now,
   revisit in Unit 4 if needed.
-- Skip *Pricing* export (not useful for spend caps).
+- Skip _Pricing_ export (not useful for spend caps).
 
 **Test scenarios:**
-- *Happy path:* ~24h after save, `bq ls blog-towles-production:billing_export` lists
+
+- _Happy path:_ ~24h after save, `bq ls blog-towles-production:billing_export` lists
   a table named `gcp_billing_export_v1_015529_D0D3BB_5BEDEE`.
-- *Error path — IAM missing:* if the billing-export service agent
+- _Error path — IAM missing:_ if the billing-export service agent
   (`service-<project_number>@gcp-sa-billing-bq-exp.iam.gserviceaccount.com`) wasn't
   granted `roles/bigquery.dataEditor` on the dataset, the console save will fail with
   a permission error. Unit 1's `google_bigquery_dataset_iam_member` should have
   handled this — if it didn't, re-check the grant.
-- *Edge case — service agent not yet provisioned:* the billing-export service agent
+- _Edge case — service agent not yet provisioned:_ the billing-export service agent
   is typically created by Google the first time BQ export is configured on a billing
   account. Unit 1's `google_bigquery_dataset_iam_member` does not validate principals,
   so the grant is accepted regardless. After the console save in Unit 2, re-check the
@@ -331,7 +337,8 @@ BigQuery dataset exist. No budgets yet — `project_caps = {}` means zero
   relocated the agent, `terraform apply` again to refresh the binding.
 
 **Verification:**
-- Console shows the export as *Configured* with the correct project/dataset.
+
+- Console shows the export as _Configured_ with the correct project/dataset.
 - After 24h, a trivial BQ query returns rows:
   ```sql
   SELECT COUNT(*) AS row_count, MAX(usage_start_time) AS latest
@@ -342,16 +349,15 @@ BigQuery dataset exist. No budgets yet — `project_caps = {}` means zero
 
 - [x] **Unit 3: Smoke-test the kill-switch with a dry-run publish** ✅ passed 2026-04-14
 
-    **Note for future reference:** the initial function deploy used a bare
-    `exports.killSwitch = (cloudEvent) => {...}` export, which the Functions
-    Framework interpreted as a 1st-gen background signature — causing every invocation
-    to log "No Pub/Sub message payload; ignoring" because `cloudEvent.data.message.data`
-    was undefined under that shape. Fix: added `@google-cloud/functions-framework` as
-    a dependency and switched to explicit CloudEvent registration via
-    `functions.cloudEvent('killSwitch', async (cloudEvent) => {...})`. All 4 test
-    scenarios (dry-run, missing fields, below-cap, allowlist-reject) pass after
-    redeploy. Zero UpdateBillingInfo audit events, confirming guards are tight.
-
+  **Note for future reference:** the initial function deploy used a bare
+  `exports.killSwitch = (cloudEvent) => {...}` export, which the Functions
+  Framework interpreted as a 1st-gen background signature — causing every invocation
+  to log "No Pub/Sub message payload; ignoring" because `cloudEvent.data.message.data`
+  was undefined under that shape. Fix: added `@google-cloud/functions-framework` as
+  a dependency and switched to explicit CloudEvent registration via
+  `functions.cloudEvent('killSwitch', async (cloudEvent) => {...})`. All 4 test
+  scenarios (dry-run, missing fields, below-cap, allowlist-reject) pass after
+  redeploy. Zero UpdateBillingInfo audit events, confirming guards are tight.
 
 **Goal:** Verify the full path — Pub/Sub → Eventarc → Cloud Run function invocation
 → Cloud Logging — works end-to-end before any real budget is wired up. Use a payload
@@ -365,26 +371,29 @@ log-and-exits without touching billing.
 **Files:** None — runtime verification only.
 
 **Approach:**
+
 - Publish a synthetic payload via `gcloud pubsub topics publish billing-cap-alerts
-  --project=blog-towles-production --message='{"budgetDisplayName":"dry-run",…}'`
+--project=blog-towles-production --message='{"budgetDisplayName":"dry-run",…}'`
   (exact command in `infra/gcp-billing/README.md`).
 - Immediately tail the function logs:
   `gcloud functions logs read billing-kill-switch --gen2 --region=us-central1
-  --project=blog-towles-production --limit=50`.
+--project=blog-towles-production --limit=50`.
 - Expect a log line containing `Ignoring: budgetDisplayName "dry-run" does not match
-  spend-cap-<project>`.
+spend-cap-<project>`.
 
 **Test scenarios:**
-- *Happy path — dry-run message:* `budgetDisplayName: "dry-run"` → function logs
+
+- _Happy path — dry-run message:_ `budgetDisplayName: "dry-run"` → function logs
   "Ignoring…" and exits.
-- *Edge case — missing costAmount/budgetAmount:* payload with only `budgetDisplayName`
+- _Edge case — missing costAmount/budgetAmount:_ payload with only `budgetDisplayName`
   set → function logs "costAmount/budgetAmount missing or non-numeric" and exits.
-- *Edge case — below-threshold payload:* `budgetDisplayName: "spend-cap-fake-project"`,
+- _Edge case — below-threshold payload:_ `budgetDisplayName: "spend-cap-fake-project"`,
   `costAmount: 1`, `budgetAmount: 100` → function logs "Below cap (cost=1 <
   budget=100); no action" and exits. Proves the threshold guard works without
   requiring a real project.
 
 **Verification:**
+
 - All three log messages appear in Cloud Logging.
 - Function execution metrics show 3 successful invocations, 0 errors.
 - No `cloudbilling.googleapis.com` audit log entries for `UpdateBillingInfo` (the
@@ -402,11 +411,13 @@ baseline and pick cap values with enough headroom to avoid tripping under normal
 **Dependencies:** Unit 2 (export must be landing data ≥ 7 days).
 
 **Files:**
+
 - Modify: `infra/gcp-billing/terraform.tfvars` (fill in `project_caps` map)
 - Create (optional, not committed): a scratch notes file with the BQ query output
   for future reference
 
 **Approach:**
+
 - Run a per-project rollup query against
   `blog-towles-production.billing_export.gcp_billing_export_v1_015529_D0D3BB_5BEDEE`:
   ```sql
@@ -432,11 +443,12 @@ baseline and pick cap values with enough headroom to avoid tripping under normal
   amount spec anyway).
 - Commit the updated `terraform.tfvars`.
 
-**Test scenarios:** — *Test expectation: none — this is an analysis and configuration
+**Test scenarios:** — _Test expectation: none — this is an analysis and configuration
 unit with no behavioral change. Verification is the baseline documentation + tfvars
-diff.*
+diff._
 
 **Verification:**
+
 - Every project on billing account `015529-D0D3BB-5BEDEE` appears as a key in
   `project_caps` (enforce R4: no gaps).
 - Every cap value is ≥ 2× observed projected monthly spend, floored at the per-tier
@@ -463,11 +475,13 @@ ongoing spend anyway).
 canary cap is set below it).
 
 **Files:**
+
 - Modify: `infra/gcp-billing/terraform.tfvars` — temporarily set
   `project_caps = { "blog-towles-staging" = <N> }` where N is clearly below staging's
   current MTD spend. All other projects remain absent from the map for this step.
 
 **Approach:**
+
 - Confirm staging's current MTD spend from the BQ query in Unit 4 (e.g., if MTD is
   $3.50, set cap to `1`).
 - `terraform apply -var-file=terraform.tfvars` — creates only the staging budget
@@ -479,7 +493,7 @@ canary cap is set below it).
   - Budget notification published to topic (visible in Pub/Sub subscription metrics
     or `gcloud pubsub` read).
   - Cloud Function logs show: `"Disabling billing on blog-towles-staging (cost=X >=
-    budget=<N>)"`.
+budget=<N>)"`.
   - `gcloud billing projects describe blog-towles-staging` returns
     `billingEnabled: false`.
   - Cloud SQL instance in staging is unreachable; Cloud Run staging service returns
@@ -498,32 +512,35 @@ canary cap is set below it).
   real cap, not $1).
 
 **Patterns to follow:**
+
 - The existing `cost-scheduler` module in `infra/terraform/modules/cost-scheduler/`
   already uses `google_cloudfunctions2_function` and a Pub/Sub-adjacent trigger
   pattern; this unit's reasoning about re-enable and Cloud SQL recovery is informed
   by that module's operational behavior.
 
 **Test scenarios:**
-- *Happy path — real over-cap trip:* budget with `specified_amount < MTD cost` fires
+
+- _Happy path — real over-cap trip:_ budget with `specified_amount < MTD cost` fires
   within 1–24h, function disables billing on staging, `billingEnabled: false`.
-- *Edge case — idempotent retrips:* subsequent budget evaluations during the
+- _Edge case — idempotent retrips:_ subsequent budget evaluations during the
   billing-disabled window invoke the function; it log-and-exits without duplicate
   `updateBillingInfo` calls. Proves the `getBillingInfo` idempotency guard works
   with real API responses.
-- *Error path — IAM insufficient (diagnostic):* if `roles/billing.admin` on the
+- _Error path — IAM insufficient (diagnostic):_ if `roles/billing.admin` on the
   function SA is somehow not fully propagated, the function errors on
   `updateBillingInfo` with PERMISSION_DENIED and `RETRY_POLICY_RETRY` re-invokes.
   Cloud Logging shows the error. Expected diagnostic outcome — do NOT proceed to
   Unit 6 until this test passes cleanly.
-- *Edge case — ALLOWED_PROJECTS allowlist:* verify by publishing a synthetic payload
-  with `budgetDisplayName: "spend-cap-jarvis-home-487516"` *before* Unit 6 arms
+- _Edge case — ALLOWED_PROJECTS allowlist:_ verify by publishing a synthetic payload
+  with `budgetDisplayName: "spend-cap-jarvis-home-487516"` _before_ Unit 6 arms
   jarvis's cap. The allowlist contains only `blog-towles-staging` at this point, so
   the function must log `"Refusing: projectId \"jarvis-home-487516\" not in
-  ALLOWED_PROJECTS allowlist"` and exit. Proves the forged-trip defense.
+ALLOWED_PROJECTS allowlist"` and exit. Proves the forged-trip defense.
 
 **Verification:**
+
 - `gcloud billing projects describe blog-towles-staging` showed `billingEnabled:
-  false` during the window, then `true` after re-link.
+false` during the window, then `true` after re-link.
 - Cloud Audit Logs show exactly one successful `UpdateBillingInfo` call for the
   staging project during the window; subsequent retrips did not re-call it.
 - Staging site/services recovered without data loss after re-enable.
@@ -542,10 +559,12 @@ publish to the Pub/Sub topic; kill-switch will fire on a 100% crossing.
 **Dependencies:** Unit 5 must have passed cleanly (real IAM path proven).
 
 **Files:**
+
 - Modify: `infra/gcp-billing/terraform.tfvars` — set the full `project_caps` map
   from Unit 4 (not the sub-$1 staging-only map from Unit 5).
 
 **Approach:**
+
 - `terraform plan -var-file=terraform.tfvars` — verify:
   - Staging budget updates in place (from $1 back to its real cap).
   - All other project budgets are created.
@@ -556,24 +575,27 @@ publish to the Pub/Sub topic; kill-switch will fire on a 100% crossing.
   present and threshold rules at 50/90/100%.
 
 **Patterns to follow:**
+
 - Same apply procedure as Unit 1, with the full caps map.
 
 **Test scenarios:**
-- *Happy path:* `apply` exits 0. N−1 budget creations (all projects except staging)
-  + 1 budget update (staging: $1 → real cap) + 1 function update-in-place (for
-  `ALLOWED_PROJECTS` env var).
-- *Error path — project-number lookup fails:* if `data.google_project.capped[<id>]`
+
+- _Happy path:_ `apply` exits 0. N−1 budget creations (all projects except staging)
+  - 1 budget update (staging: $1 → real cap) + 1 function update-in-place (for
+    `ALLOWED_PROJECTS` env var).
+- _Error path — project-number lookup fails:_ if `data.google_project.capped[<id>]`
   can't resolve (project renamed or removed between tfvars edit and apply), apply
   fails at plan time. Expected and safe — correct the tfvars and retry.
-- *Integration:* After apply,
+- _Integration:_ After apply,
   `gcloud billing budgets list --billing-account=015529-D0D3BB-5BEDEE` shows N
   budgets, each with `displayName` matching `spend-cap-<project_id>`.
-- *R4 coverage check:* the set difference
+- _R4 coverage check:_ the set difference
   `gcloud billing projects list --billing-account=015529-D0D3BB-5BEDEE
-   --format='value(projectId)'` minus `keys(var.project_caps)` is empty. Any project
+ --format='value(projectId)'` minus `keys(var.project_caps)` is empty. Any project
   on the billing account without a cap is an R4 violation.
 
 **Verification:**
+
 - Every project listed by
   `gcloud billing projects list --billing-account=015529-D0D3BB-5BEDEE` has a
   corresponding budget (R4 coverage check, above).
@@ -582,8 +604,8 @@ publish to the Pub/Sub topic; kill-switch will fire on a 100% crossing.
 - Terraform state contains exactly N `google_billing_budget.project_cap` entries.
 - Function's deployed `ALLOWED_PROJECTS` env var contains every project_id (not just
   staging). Verify via `gcloud functions describe billing-kill-switch --gen2
-  --region=us-central1 --project=blog-towles-production
-  --format='value(serviceConfig.environmentVariables.ALLOWED_PROJECTS)'`.
+--region=us-central1 --project=blog-towles-production
+--format='value(serviceConfig.environmentVariables.ALLOWED_PROJECTS)'`.
 
 ## System-Wide Impact
 
@@ -612,19 +634,19 @@ publish to the Pub/Sub topic; kill-switch will fire on a 100% crossing.
 
 ## Risks & Dependencies
 
-| Risk | Mitigation |
-|------|------------|
-| **Budget-notification latency (4–24h) means spend can burn past cap before trip fires.** | Documented as a Known Limitation in Problem Frame. Cap sizing in Unit 4 should price in worst-case 1-day burn rate, not treat the cap as a real-time ceiling. Per-service preventive quotas (deferred to a separate task) are the complementary mechanism for real-time spend bounding. |
-| **Host project (`blog-towles-production`) self-kill takes the kill-switch offline.** | Accepted limitation: the in-flight kill completes synchronously before the function's own billing is disabled, so the trip itself isn't lost. Other projects are temporarily unprotected from *new* trips until the host is re-linked. Mitigation = keep prod's cap high enough that it rarely trips, and monitor the billing-admin email that fires on any trip. |
-| **A cap set too low trips the production blog.** | Unit 4 enforces `≥ 2× observed baseline` and a `$50` floor for `blog-towles-production`. If uncertain, err higher — the cap can always be lowered later. |
-| **BigQuery export never starts landing data.** | Unit 2 explicitly depends on the dataset-IAM grant from Unit 1. Verification query in Unit 2 checks for data within 24h. If absent, first place to check is the billing-export SA's `bigquery.dataEditor` grant on the dataset. |
-| **IAM insufficient or unpropagated when first real trip fires.** | Using `roles/billing.admin` (not the narrower `roles/billing.projectManager`) eliminates role-sufficiency uncertainty. Unit 5's staging sub-cap canary is mandatory and exercises the real `updateBillingInfo` IAM path end-to-end before Unit 6 arms any remaining caps. |
-| **Forged Pub/Sub message from an identity with project-level `roles/editor` could disable billing on an unrelated project.** | Function enforces an `ALLOWED_PROJECTS` allowlist derived from `var.project_caps`; any projectId not in the allowlist is rejected and logged. Topic-level IAM additionally grants publish only to the billing-budgets service agent (defense in depth; project-level IAM can still inherit publish). |
-| **Billing-admin email notifications are the only human signal of a trip.** | Acceptable for v1; default IAM recipients are enabled in `budgets.tf`. Notification upgrade (Slack/pager) is explicitly deferred. |
-| **`gen-lang-client-0238175572` is auto-provisioned by a Google service and can't be unlinked.** | Unit 4 inspects this specifically. Fallback: give it a minimal cap ($10) like any other project. |
-| **Provider version drift between `validate` time and real `apply` time.** | Commit `.terraform.lock.hcl` after Unit 1's `init` so subsequent applies are pinned. |
-| **Applying user's identity lacks `roles/billing.admin` on the billing account.** | Plan fails at `google_billing_account_iam_member` with a clear error. User elevates permissions and retries — no partial state because the resource hadn't been created yet. |
-| **Budget manually edited or deleted in the Billing Console** (e.g., display name changed, breaking the `spend-cap-<project_id>` convention) **causes silent Terraform drift.** | Accepted. Re-running `terraform apply` on this stack restores the intended state. No scheduled drift detection is configured. |
+| Risk                                                                                                                                                                           | Mitigation                                                                                                                                                                                                                                                                                                                                                        |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Budget-notification latency (4–24h) means spend can burn past cap before trip fires.**                                                                                       | Documented as a Known Limitation in Problem Frame. Cap sizing in Unit 4 should price in worst-case 1-day burn rate, not treat the cap as a real-time ceiling. Per-service preventive quotas (deferred to a separate task) are the complementary mechanism for real-time spend bounding.                                                                           |
+| **Host project (`blog-towles-production`) self-kill takes the kill-switch offline.**                                                                                           | Accepted limitation: the in-flight kill completes synchronously before the function's own billing is disabled, so the trip itself isn't lost. Other projects are temporarily unprotected from _new_ trips until the host is re-linked. Mitigation = keep prod's cap high enough that it rarely trips, and monitor the billing-admin email that fires on any trip. |
+| **A cap set too low trips the production blog.**                                                                                                                               | Unit 4 enforces `≥ 2× observed baseline` and a `$50` floor for `blog-towles-production`. If uncertain, err higher — the cap can always be lowered later.                                                                                                                                                                                                          |
+| **BigQuery export never starts landing data.**                                                                                                                                 | Unit 2 explicitly depends on the dataset-IAM grant from Unit 1. Verification query in Unit 2 checks for data within 24h. If absent, first place to check is the billing-export SA's `bigquery.dataEditor` grant on the dataset.                                                                                                                                   |
+| **IAM insufficient or unpropagated when first real trip fires.**                                                                                                               | Using `roles/billing.admin` (not the narrower `roles/billing.projectManager`) eliminates role-sufficiency uncertainty. Unit 5's staging sub-cap canary is mandatory and exercises the real `updateBillingInfo` IAM path end-to-end before Unit 6 arms any remaining caps.                                                                                         |
+| **Forged Pub/Sub message from an identity with project-level `roles/editor` could disable billing on an unrelated project.**                                                   | Function enforces an `ALLOWED_PROJECTS` allowlist derived from `var.project_caps`; any projectId not in the allowlist is rejected and logged. Topic-level IAM additionally grants publish only to the billing-budgets service agent (defense in depth; project-level IAM can still inherit publish).                                                              |
+| **Billing-admin email notifications are the only human signal of a trip.**                                                                                                     | Acceptable for v1; default IAM recipients are enabled in `budgets.tf`. Notification upgrade (Slack/pager) is explicitly deferred.                                                                                                                                                                                                                                 |
+| **`gen-lang-client-0238175572` is auto-provisioned by a Google service and can't be unlinked.**                                                                                | Unit 4 inspects this specifically. Fallback: give it a minimal cap ($10) like any other project.                                                                                                                                                                                                                                                                  |
+| **Provider version drift between `validate` time and real `apply` time.**                                                                                                      | Commit `.terraform.lock.hcl` after Unit 1's `init` so subsequent applies are pinned.                                                                                                                                                                                                                                                                              |
+| **Applying user's identity lacks `roles/billing.admin` on the billing account.**                                                                                               | Plan fails at `google_billing_account_iam_member` with a clear error. User elevates permissions and retries — no partial state because the resource hadn't been created yet.                                                                                                                                                                                      |
+| **Budget manually edited or deleted in the Billing Console** (e.g., display name changed, breaking the `spend-cap-<project_id>` convention) **causes silent Terraform drift.** | Accepted. Re-running `terraform apply` on this stack restores the intended state. No scheduled drift detection is configured.                                                                                                                                                                                                                                     |
 
 ## Documentation / Operational Notes
 
@@ -634,7 +656,7 @@ publish to the Pub/Sub topic; kill-switch will fire on a 100% crossing.
   cap-sizing methodology.
 - After Unit 4, consider leaving a comment in `terraform.tfvars` documenting the
   date and methodology of the cap numbers (e.g., `# Caps set 2026-04-28 from 14-day
-  baseline; see docs/plans/2026-04-14-001 for method`).
+baseline; see docs/plans/2026-04-14-001 for method`).
 - No runbook, no on-call impact — this is a defensive kill-switch for a personal
   billing account, not a production service.
 

--- a/infra/gcp-billing/.gitignore
+++ b/infra/gcp-billing/.gitignore
@@ -1,0 +1,5 @@
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+function.zip

--- a/infra/gcp-billing/README.md
+++ b/infra/gcp-billing/README.md
@@ -1,0 +1,176 @@
+# GCP billing: spend cap + BigQuery export
+
+Hard kill-switch for every project on billing account `015529-D0D3BB-5BEDEE`, plus a
+BigQuery billing export so you can actually see what each project costs.
+
+## How it works
+
+```
+Cloud Billing budget (per project)
+        │  (threshold crossed)
+        ▼
+Pub/Sub topic: billing-cap-alerts
+        │  (messagePublished)
+        ▼
+Cloud Function: billing-kill-switch
+        │  costAmount >= budgetAmount ?
+        ▼
+cloudbilling.projects.updateBillingInfo(project, billingAccountName="")
+        │
+        ▼
+Billing disabled on that project. Most services stop within minutes.
+```
+
+- **One budget per project.** The budget's `displayName` is `spend-cap-<project_id>`; the
+  function parses that to know which project to disable billing on. Blast radius is limited
+  to the project that tripped.
+- **Shared topic + function.** All budgets publish to the same topic; the single function
+  fans out by display name.
+- **Idempotent.** If billing is already off on a project, the function logs and exits.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `main.tf` | Provider, backend, API enablement |
+| `variables.tf` | Input variables |
+| `terraform.tfvars` | Billing account + host project + `project_caps` map |
+| `backend.tfvars` | GCS backend bucket |
+| `bigquery_export.tf` | BigQuery dataset for billing export |
+| `pubsub_function.tf` | Pub/Sub topic, service account, Cloud Function |
+| `budgets.tf` | Per-project `google_billing_budget` (for_each over `project_caps`) |
+| `outputs.tf` | Topic, function, dataset names |
+| `function/` | Node.js 20 Cloud Function source |
+
+## Phased rollout
+
+The `project_caps` variable defaults to `{}`, so you can apply the infra **without any
+budgets** and leave the kill-switch armed-but-inert until you have spend data.
+
+### Phase 1 — Infra + BigQuery export (now)
+
+```bash
+cd infra/gcp-billing
+terraform init -backend-config=backend.tfvars
+terraform validate
+terraform plan  -var-file=terraform.tfvars
+terraform apply -var-file=terraform.tfvars
+```
+
+After apply, **enable the BigQuery export manually** (Terraform can't do this — there's
+no GCP provider resource for the export itself):
+
+1. Open <https://console.cloud.google.com/billing/015529-D0D3BB-5BEDEE/export>
+2. Under **BigQuery export**, click **Edit settings** next to *Standard usage cost*.
+3. Project: `blog-towles-production` · Dataset: `billing_export` · Click **Save**.
+4. Repeat for **Detailed usage cost** if you want per-SKU granularity.
+
+Data starts landing within ~24h. Query it:
+
+```sql
+SELECT project.id, SUM(cost) AS cost
+FROM `blog-towles-production.billing_export.gcp_billing_export_v1_015529_D0D3BB_5BEDEE`
+WHERE invoice.month = FORMAT_DATE('%Y%m', CURRENT_DATE())
+GROUP BY project.id
+ORDER BY cost DESC;
+```
+
+### Phase 2 — Flip on the caps (later)
+
+Edit `terraform.tfvars` and set real numbers:
+
+```hcl
+project_caps = {
+  "blog-towles-production"     = 50
+  "blog-towles-staging"        = 15
+  "blog-chris-towles"          = 15
+  "jarvis-home-487516"         = 10
+  "progression-labs-stage"     = 10
+  "gen-lang-client-0238175572" = 10
+}
+```
+
+Then:
+
+```bash
+terraform apply -var-file=terraform.tfvars
+```
+
+## Testing the kill-switch without waiting for real spend
+
+Publish a synthetic budget notification to the topic. Substitute the project you want
+to target:
+
+```bash
+PROJECT_ID=jarvis-home-487516
+HOST=blog-towles-production
+
+# Mimics the schema 1.0 budget-alert payload.
+PAYLOAD=$(cat <<JSON
+{
+  "budgetDisplayName": "spend-cap-${PROJECT_ID}",
+  "alertThresholdExceeded": 1.0,
+  "costAmount": 999.99,
+  "budgetAmount": 10.00,
+  "budgetAmountType": "SPECIFIED_AMOUNT",
+  "currencyCode": "USD"
+}
+JSON
+)
+
+gcloud pubsub topics publish billing-cap-alerts \
+  --project="${HOST}" \
+  --message="${PAYLOAD}"
+```
+
+**Warning:** this will actually disable billing on the named project. To do a dry-run
+without tripping, target a display name that does not start with `spend-cap-` — the
+function will log-and-exit.
+
+```bash
+gcloud pubsub topics publish billing-cap-alerts \
+  --project="${HOST}" \
+  --message='{"budgetDisplayName":"dry-run","costAmount":1,"budgetAmount":0}'
+
+# Check logs:
+gcloud functions logs read billing-kill-switch \
+  --project="${HOST}" --region=us-central1 --gen2 --limit=50
+```
+
+## Re-enabling billing after the switch trips
+
+There is no automated "turn it back on" flow — that's the point. You do it by hand:
+
+```bash
+PROJECT_ID=jarvis-home-487516
+
+gcloud billing projects link "${PROJECT_ID}" \
+  --billing-account=015529-D0D3BB-5BEDEE
+```
+
+Or in the console: **Billing → Account Management → Link a billing account → select
+`015529-D0D3BB-5BEDEE`**.
+
+Before re-linking, figure out *why* it tripped — check the BigQuery export or the
+Billing Reports console, filtered to the affected project. Otherwise you'll just burn
+through the cap again.
+
+## Required permissions (running `terraform apply`)
+
+The applying user (you) needs, in addition to normal project-edit rights on
+`blog-towles-production`:
+
+- `roles/billing.admin` on billing account `015529-D0D3BB-5BEDEE` — to grant
+  `roles/billing.projectManager` to the function SA and to create budgets.
+- `roles/resourcemanager.projectIamAdmin` on each capped project (only relevant if
+  `roles/billing.admin` isn't already enough).
+
+The function's runtime SA (`billing-kill-switch@…`) is granted only
+`roles/billing.projectManager` on the billing account — the minimum needed to call
+`updateBillingInfo(billingAccountName="")`.
+
+## Out of scope
+
+- Per-service quotas (use `compute.googleapis.com/quotas` or `serviceusage` for that).
+- Cost anomaly detection.
+- Automated re-enable flow (intentionally manual).

--- a/infra/gcp-billing/README.md
+++ b/infra/gcp-billing/README.md
@@ -30,17 +30,17 @@ Billing disabled on that project. Most services stop within minutes.
 
 ## Files
 
-| File | Purpose |
-|---|---|
-| `main.tf` | Provider, backend, API enablement |
-| `variables.tf` | Input variables |
-| `terraform.tfvars` | Billing account + host project + `project_caps` map |
-| `backend.tfvars` | GCS backend bucket |
-| `bigquery_export.tf` | BigQuery dataset for billing export |
-| `pubsub_function.tf` | Pub/Sub topic, service account, Cloud Function |
-| `budgets.tf` | Per-project `google_billing_budget` (for_each over `project_caps`) |
-| `outputs.tf` | Topic, function, dataset names |
-| `function/` | Node.js 20 Cloud Function source |
+| File                 | Purpose                                                            |
+| -------------------- | ------------------------------------------------------------------ |
+| `main.tf`            | Provider, backend, API enablement                                  |
+| `variables.tf`       | Input variables                                                    |
+| `terraform.tfvars`   | Billing account + host project + `project_caps` map                |
+| `backend.tfvars`     | GCS backend bucket                                                 |
+| `bigquery_export.tf` | BigQuery dataset for billing export                                |
+| `pubsub_function.tf` | Pub/Sub topic, service account, Cloud Function                     |
+| `budgets.tf`         | Per-project `google_billing_budget` (for_each over `project_caps`) |
+| `outputs.tf`         | Topic, function, dataset names                                     |
+| `function/`          | Node.js 20 Cloud Function source                                   |
 
 ## Phased rollout
 
@@ -61,7 +61,7 @@ After apply, **enable the BigQuery export manually** (Terraform can't do this �
 no GCP provider resource for the export itself):
 
 1. Open <https://console.cloud.google.com/billing/015529-D0D3BB-5BEDEE/export>
-2. Under **BigQuery export**, click **Edit settings** next to *Standard usage cost*.
+2. Under **BigQuery export**, click **Edit settings** next to _Standard usage cost_.
 3. Project: `blog-towles-production` · Dataset: `billing_export` · Click **Save**.
 4. Repeat for **Detailed usage cost** if you want per-SKU granularity.
 
@@ -151,7 +151,7 @@ gcloud billing projects link "${PROJECT_ID}" \
 Or in the console: **Billing → Account Management → Link a billing account → select
 `015529-D0D3BB-5BEDEE`**.
 
-Before re-linking, figure out *why* it tripped — check the BigQuery export or the
+Before re-linking, figure out _why_ it tripped — check the BigQuery export or the
 Billing Reports console, filtered to the affected project. Otherwise you'll just burn
 through the cap again.
 

--- a/infra/gcp-billing/backend.tfvars
+++ b/infra/gcp-billing/backend.tfvars
@@ -1,0 +1,1 @@
+bucket = "blog-towles-production-tfstate"

--- a/infra/gcp-billing/bigquery_export.tf
+++ b/infra/gcp-billing/bigquery_export.tf
@@ -1,0 +1,28 @@
+# BigQuery dataset that will receive Cloud Billing export data.
+#
+# NOTE: Terraform cannot enable the actual export. After apply, a human has to flip
+# the switch once in the Billing Console (see README). Terraform manages the dataset
+# and the IAM that lets the billing-export service agent write into it.
+
+resource "google_bigquery_dataset" "billing_export" {
+  project                    = var.host_project_id
+  dataset_id                 = var.bigquery_dataset_id
+  location                   = var.bigquery_location
+  description                = "Cloud Billing export (standard + detailed usage cost). Enabled manually in Billing Console."
+  delete_contents_on_destroy = false
+
+  depends_on = [google_project_service.apis]
+}
+
+# Lookup used elsewhere in the stack (pubsub_function.tf).
+data "google_project" "host" {
+  project_id = var.host_project_id
+}
+
+# NOTE: We intentionally do NOT create a google_bigquery_dataset_iam_member for the
+# billing-export service agent (service-<project_number>@gcp-sa-billing-bq-exp.iam.gserviceaccount.com).
+# That service agent is provisioned by Google only when Cloud Billing's BigQuery export
+# is first configured against this billing account — which happens in Unit 2 of the rollout
+# plan, not during Terraform apply. Pre-granting IAM to a non-existent principal fails with
+# "Service account ... does not exist". Google auto-grants the required dataEditor role
+# on the dataset when the console export is enabled, so this Terraform does not need to.

--- a/infra/gcp-billing/budgets.tf
+++ b/infra/gcp-billing/budgets.tf
@@ -1,0 +1,50 @@
+# Per-project Cloud Billing budgets. One budget per entry in var.project_caps.
+# The budget's displayName encodes the project_id so the kill-switch function
+# knows which project to disable billing on when the cap is hit.
+
+# Look up the project number for each capped project (the budget_filter API
+# requires "projects/<number>", not "projects/<id>").
+data "google_project" "capped" {
+  for_each   = var.project_caps
+  project_id = each.key
+}
+
+resource "google_billing_budget" "project_cap" {
+  for_each = var.project_caps
+
+  billing_account = var.billing_account_id
+  display_name    = "spend-cap-${each.key}"
+
+  budget_filter {
+    projects               = ["projects/${data.google_project.capped[each.key].number}"]
+    credit_types_treatment = "INCLUDE_ALL_CREDITS"
+  }
+
+  amount {
+    specified_amount {
+      currency_code = "USD"
+      units         = tostring(each.value)
+    }
+  }
+
+  threshold_rules {
+    threshold_percent = 0.5
+    spend_basis       = "CURRENT_SPEND"
+  }
+  threshold_rules {
+    threshold_percent = 0.9
+    spend_basis       = "CURRENT_SPEND"
+  }
+  threshold_rules {
+    threshold_percent = 1.0
+    spend_basis       = "CURRENT_SPEND"
+  }
+
+  all_updates_rule {
+    pubsub_topic                   = google_pubsub_topic.billing_alerts.id
+    disable_default_iam_recipients = false
+    schema_version                 = "1.0"
+  }
+
+  depends_on = [google_project_service.apis]
+}

--- a/infra/gcp-billing/function/index.js
+++ b/infra/gcp-billing/function/index.js
@@ -1,0 +1,86 @@
+const functions = require('@google-cloud/functions-framework');
+const { google } = require('googleapis');
+
+const PROJECT_PREFIX = 'projects/';
+const DISPLAY_NAME_PREFIX = 'spend-cap-';
+
+// Allowlist of project IDs this function is permitted to disable billing on.
+// Set by Terraform from var.project_caps. Comma-separated. Empty/unset means
+// no project is allowed — the kill-switch is effectively disabled at the
+// function layer until Terraform arms it.
+const ALLOWED_PROJECTS = new Set(
+  (process.env.ALLOWED_PROJECTS || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
+
+// Pub/Sub event handler for 2nd-gen Cloud Functions (CloudEvents).
+// Budget notification payload:
+//   {
+//     "budgetDisplayName": "spend-cap-<project_id>",
+//     "alertThresholdExceeded": 1.0,
+//     "costAmount": 12.34,
+//     "budgetAmount": 10.0,
+//     "budgetAmountType": "SPECIFIED_AMOUNT",
+//     "currencyCode": "USD"
+//   }
+functions.cloudEvent('killSwitch', async (cloudEvent) => {
+  const rawData = cloudEvent?.data?.message?.data;
+  if (!rawData) {
+    console.log('No Pub/Sub message payload; ignoring');
+    return;
+  }
+
+  const payload = JSON.parse(Buffer.from(rawData, 'base64').toString('utf-8'));
+  console.log('Budget notification:', JSON.stringify(payload));
+
+  const { budgetDisplayName, costAmount, budgetAmount } = payload;
+
+  if (!budgetDisplayName || !budgetDisplayName.startsWith(DISPLAY_NAME_PREFIX)) {
+    console.log(
+      `Ignoring: budgetDisplayName "${budgetDisplayName}" does not match ${DISPLAY_NAME_PREFIX}<project>`,
+    );
+    return;
+  }
+
+  if (typeof costAmount !== 'number' || typeof budgetAmount !== 'number') {
+    console.log('Ignoring: costAmount/budgetAmount missing or non-numeric');
+    return;
+  }
+
+  if (costAmount < budgetAmount) {
+    console.log(`Below cap (cost=${costAmount} < budget=${budgetAmount}); no action`);
+    return;
+  }
+
+  const projectId = budgetDisplayName.slice(DISPLAY_NAME_PREFIX.length);
+
+  if (!ALLOWED_PROJECTS.has(projectId)) {
+    console.log(`Refusing: projectId "${projectId}" not in ALLOWED_PROJECTS allowlist`);
+    return;
+  }
+
+  const projectName = `${PROJECT_PREFIX}${projectId}`;
+
+  const auth = new google.auth.GoogleAuth({
+    scopes: ['https://www.googleapis.com/auth/cloud-billing'],
+  });
+  const billing = google.cloudbilling({ version: 'v1', auth });
+
+  // Idempotency: if billing is already disabled, exit cleanly.
+  const current = await billing.projects.getBillingInfo({ name: projectName });
+  if (current.data.billingEnabled !== true) {
+    console.log(`Billing already disabled on ${projectId}; exiting idempotently`);
+    return;
+  }
+
+  console.log(`Disabling billing on ${projectId} (cost=${costAmount} >= budget=${budgetAmount})`);
+
+  const result = await billing.projects.updateBillingInfo({
+    name: projectName,
+    requestBody: { billingAccountName: '' },
+  });
+
+  console.log(`Billing disabled. New state: ${JSON.stringify(result.data)}`);
+});

--- a/infra/gcp-billing/function/package.json
+++ b/infra/gcp-billing/function/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "billing-kill-switch",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "@google-cloud/functions-framework": "^3.4.0",
+    "googleapis": "^140.0.1"
+  }
+}

--- a/infra/gcp-billing/main.tf
+++ b/infra/gcp-billing/main.tf
@@ -1,0 +1,45 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.4"
+    }
+  }
+
+  backend "gcs" {
+    prefix = "terraform/gcp-billing"
+    # bucket set via -backend-config
+  }
+}
+
+provider "google" {
+  project = var.host_project_id
+  region  = var.region
+}
+
+# ---- APIs on the host project ----
+resource "google_project_service" "apis" {
+  for_each = toset([
+    "billingbudgets.googleapis.com",
+    "cloudbilling.googleapis.com",
+    "cloudfunctions.googleapis.com",
+    "pubsub.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "run.googleapis.com",
+    "eventarc.googleapis.com",
+    "bigquery.googleapis.com",
+    "iam.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+  ])
+
+  project                    = var.host_project_id
+  service                    = each.key
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}

--- a/infra/gcp-billing/outputs.tf
+++ b/infra/gcp-billing/outputs.tf
@@ -1,0 +1,24 @@
+output "pubsub_topic" {
+  description = "Pub/Sub topic that budgets publish to."
+  value       = google_pubsub_topic.billing_alerts.id
+}
+
+output "function_name" {
+  description = "Kill-switch Cloud Function name."
+  value       = google_cloudfunctions2_function.kill_switch.name
+}
+
+output "function_service_account" {
+  description = "Runtime SA for the kill-switch function."
+  value       = google_service_account.kill_switch.email
+}
+
+output "bigquery_dataset" {
+  description = "Dataset the Billing Console export should write to."
+  value       = "${var.host_project_id}.${google_bigquery_dataset.billing_export.dataset_id}"
+}
+
+output "configured_caps" {
+  description = "Per-project caps currently provisioned."
+  value       = var.project_caps
+}

--- a/infra/gcp-billing/pubsub_function.tf
+++ b/infra/gcp-billing/pubsub_function.tf
@@ -1,0 +1,131 @@
+# ---- Pub/Sub topic that budgets publish to ----
+resource "google_pubsub_topic" "billing_alerts" {
+  project = var.host_project_id
+  name    = var.pubsub_topic_name
+
+  depends_on = [google_project_service.apis]
+}
+
+# NOTE: We intentionally do NOT create a topic-level iam_member for the billing-budgets
+# service agent (service-<project_number>@gcp-sa-billingbudgets.iam.gserviceaccount.com).
+# That service agent doesn't exist until the first google_billing_budget on this billing
+# account is created — which happens in Unit 5 (staging canary) and Unit 6 (Phase 2 apply),
+# not here. Google auto-grants the publisher role on the topic when the first budget
+# points at it, so pre-granting would both fail (principal doesn't exist) and be redundant.
+# The authoritative guard against forged trips is the ALLOWED_PROJECTS allowlist in the
+# function (see service_config below), not topic-level IAM.
+
+# ---- Service account used by the Cloud Function runtime ----
+resource "google_service_account" "kill_switch" {
+  project      = var.host_project_id
+  account_id   = var.function_sa_id
+  display_name = "Billing cap kill-switch"
+}
+
+# Disabling billing on a project (calling updateBillingInfo with an empty
+# billingAccountName) requires permissions that Google's canonical sample uses
+# roles/billing.admin for. roles/billing.projectManager is documented as sufficient
+# for linking projects, but there are reports of it being insufficient for unlinking
+# in some configurations. Using roles/billing.admin eliminates that uncertainty
+# at the cost of a slightly broader role on this billing account only.
+resource "google_billing_account_iam_member" "kill_switch_billing_admin" {
+  billing_account_id = var.billing_account_id
+  role               = "roles/billing.admin"
+  member             = "serviceAccount:${google_service_account.kill_switch.email}"
+}
+
+# Eventarc trigger needs to receive events on behalf of this SA.
+resource "google_project_iam_member" "kill_switch_eventarc_receiver" {
+  project = var.host_project_id
+  role    = "roles/eventarc.eventReceiver"
+  member  = "serviceAccount:${google_service_account.kill_switch.email}"
+}
+
+# Cloud Run invoker (2nd-gen Cloud Functions run on Cloud Run).
+resource "google_project_iam_member" "kill_switch_run_invoker" {
+  project = var.host_project_id
+  role    = "roles/run.invoker"
+  member  = "serviceAccount:${google_service_account.kill_switch.email}"
+}
+
+# Pub/Sub service agent needs iam.serviceAccountTokenCreator to mint auth tokens
+# for pushing events through Eventarc into Cloud Run (2nd gen pattern).
+resource "google_project_iam_member" "pubsub_token_creator" {
+  project = var.host_project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = "serviceAccount:service-${data.google_project.host.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+
+  depends_on = [google_project_service.apis]
+}
+
+# ---- Function source bucket + zipped source ----
+# Named to match the cost-scheduler module's convention so future Cloud Functions
+# in this project can share a single source bucket (each function gets its own
+# object inside, keyed by content hash).
+resource "google_storage_bucket" "function_source" {
+  project                     = var.host_project_id
+  name                        = "${var.host_project_id}-functions"
+  location                    = var.region
+  uniform_bucket_level_access = true
+  force_destroy               = true
+}
+
+data "archive_file" "kill_switch_source" {
+  type        = "zip"
+  source_dir  = "${path.module}/function"
+  output_path = "${path.module}/function.zip"
+}
+
+resource "google_storage_bucket_object" "kill_switch_source" {
+  name   = "billing-kill-switch-${data.archive_file.kill_switch_source.output_md5}.zip"
+  bucket = google_storage_bucket.function_source.name
+  source = data.archive_file.kill_switch_source.output_path
+}
+
+# ---- 2nd-gen Cloud Function triggered by Pub/Sub ----
+resource "google_cloudfunctions2_function" "kill_switch" {
+  project  = var.host_project_id
+  location = var.region
+  name     = var.function_name
+
+  build_config {
+    runtime     = "nodejs20"
+    entry_point = "killSwitch"
+    source {
+      storage_source {
+        bucket = google_storage_bucket.function_source.name
+        object = google_storage_bucket_object.kill_switch_source.name
+      }
+    }
+  }
+
+  service_config {
+    min_instance_count    = 0
+    max_instance_count    = 1
+    available_memory      = "256M"
+    timeout_seconds       = 60
+    service_account_email = google_service_account.kill_switch.email
+    environment_variables = {
+      # Allowlist enforced in the function: a kill can only target a project
+      # that appears in var.project_caps. Prevents forged Pub/Sub messages
+      # from targeting arbitrary projects even if the topic IAM is bypassed
+      # via inherited project-level roles.
+      ALLOWED_PROJECTS = join(",", keys(var.project_caps))
+    }
+  }
+
+  event_trigger {
+    trigger_region        = var.region
+    event_type            = "google.cloud.pubsub.topic.v1.messagePublished"
+    pubsub_topic          = google_pubsub_topic.billing_alerts.id
+    retry_policy          = "RETRY_POLICY_RETRY"
+    service_account_email = google_service_account.kill_switch.email
+  }
+
+  depends_on = [
+    google_project_service.apis,
+    google_project_iam_member.kill_switch_eventarc_receiver,
+    google_project_iam_member.kill_switch_run_invoker,
+    google_project_iam_member.pubsub_token_creator,
+  ]
+}

--- a/infra/gcp-billing/terraform.tfvars
+++ b/infra/gcp-billing/terraform.tfvars
@@ -1,0 +1,16 @@
+billing_account_id = "015529-D0D3BB-5BEDEE"
+host_project_id    = "blog-towles-production"
+region             = "us-central1"
+
+# Start empty. Fill in once the BigQuery billing export has a week or two of data
+# and you know what each project actually spends in a typical month.
+#
+# project_caps = {
+#   "blog-towles-production"     = 50
+#   "blog-towles-staging"        = 15
+#   "blog-chris-towles"          = 15
+#   "jarvis-home-487516"         = 10
+#   "progression-labs-stage"     = 10
+#   "gen-lang-client-0238175572" = 10
+# }
+project_caps = {}

--- a/infra/gcp-billing/variables.tf
+++ b/infra/gcp-billing/variables.tf
@@ -1,0 +1,68 @@
+variable "billing_account_id" {
+  description = "Cloud Billing account ID (e.g. 015529-D0D3BB-5BEDEE)"
+  type        = string
+}
+
+variable "host_project_id" {
+  description = "Project that hosts the Pub/Sub topic, Cloud Function, BigQuery dataset, and terraform state."
+  type        = string
+}
+
+variable "region" {
+  description = "Region for the Cloud Function and Eventarc trigger."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "bigquery_location" {
+  description = "BigQuery dataset location. Must match the region you select in the Billing Console when enabling export."
+  type        = string
+  default     = "US"
+}
+
+variable "bigquery_dataset_id" {
+  description = "BigQuery dataset for billing export. Point the Billing Console export at this dataset."
+  type        = string
+  default     = "billing_export"
+}
+
+variable "project_caps" {
+  description = <<EOT
+Map of project_id => monthly USD cap (integer). Each entry creates a Cloud Billing budget
+scoped to that project with threshold notifications at 50/90/100%. When costAmount >= budgetAmount,
+the kill-switch function disables billing on that specific project.
+
+Leave empty to provision the kill-switch infrastructure without any budgets yet. Add entries
+after you have spend visibility from the BigQuery export.
+
+Example:
+  project_caps = {
+    "blog-towles-production"     = 50
+    "blog-towles-staging"        = 15
+    "blog-chris-towles"          = 15
+    "jarvis-home-487516"         = 10
+    "progression-labs-stage"     = 10
+    "gen-lang-client-0238175572" = 10
+  }
+EOT
+  type        = map(number)
+  default     = {}
+}
+
+variable "function_name" {
+  description = "Name of the kill-switch Cloud Function."
+  type        = string
+  default     = "billing-kill-switch"
+}
+
+variable "pubsub_topic_name" {
+  description = "Name of the Pub/Sub topic that budgets notify."
+  type        = string
+  default     = "billing-cap-alerts"
+}
+
+variable "function_sa_id" {
+  description = "Account ID (prefix) for the kill-switch service account."
+  type        = string
+  default     = "billing-kill-switch"
+}


### PR DESCRIPTION
## Summary

Implements Google's canonical [billing-cap pattern](https://cloud.google.com/billing/docs/how-to/notify#cap_disable_billing) for billing account `015529-D0D3BB-5BEDEE` (all 6 projects on the account).

**Phase 1 is already deployed against the real billing account** — this PR captures the code that produced the currently-live resources. It is a **draft** because Phase 2 (arming per-project caps) is deferred to [#237](https://github.com/ChrisTowles/blog/issues/237) and won't run until ~2026-04-22 after 7+ days of BigQuery export data.

## Architecture

```
Cloud Billing budget (per project)
        │  (threshold crossed)
        ▼
Pub/Sub topic: billing-cap-alerts
        │  (messagePublished)
        ▼
Cloud Function: billing-kill-switch  (Node.js 20, 2nd-gen)
        │  1. allowlist check (ALLOWED_PROJECTS env var)
        │  2. costAmount >= budgetAmount ?
        │  3. getBillingInfo idempotency check
        ▼
cloudbilling.projects.updateBillingInfo(project, billingAccountName="")
```

- **Per-project budgets** via `for_each` over `var.project_caps`. Default is `{}` so no budgets are created until explicitly armed.
- **Shared Pub/Sub topic + Cloud Function** hosted in `blog-towles-production`.
- **Display-name convention** `spend-cap-<project_id>` is the source of truth for which project a trip targets.
- **Function-side allowlist** (`ALLOWED_PROJECTS` env var, derived from `keys(var.project_caps)`) prevents forged Pub/Sub messages from targeting arbitrary projects.
- **`roles/billing.admin` on the function SA** (scoped to the billing account) — chosen over the narrower `roles/billing.projectManager` after the plan's document-review surfaced role-sufficiency uncertainty.
- **BigQuery billing export** dataset is provisioned by Terraform; the export itself is enabled manually in the console (no GCP provider resource for it).

## What's live right now

Applied against billing account `015529-D0D3BB-5BEDEE` on 2026-04-14:

- ✅ 9 APIs enabled on `blog-towles-production`
- ✅ Pub/Sub topic `billing-cap-alerts`
- ✅ SA `billing-kill-switch@blog-towles-production.iam.gserviceaccount.com` with `roles/billing.admin` on the billing account
- ✅ GCS bucket `blog-towles-production-functions` (follows `cost-scheduler` module convention — future Cloud Functions in prod share it)
- ✅ 2nd-gen Cloud Function `billing-kill-switch`, ACTIVE
- ✅ BigQuery dataset `blog-towles-production.billing_export`, Standard usage cost export enabled
- ✅ All 4 smoke-test scenarios verified (dry-run, missing fields, below-cap, allowlist-reject)
- ✅ Zero `UpdateBillingInfo` audit events — guards proven tight

## What's deferred

Tracked in **[#237](https://github.com/ChrisTowles/blog/issues/237)**:

- Unit 4: baseline analysis + cap sizing from BQ export
- Unit 5: mandatory staging sub-cap live canary (exercises IAM path Unit 3's dry-run skipped)
- Unit 6: Phase 2 apply — arm caps on all 6 projects

## Implementation notes (deviations from original code plan)

Two changes were made during Phase 1 apply:

1. **Removed two premature `*_iam_member` bindings** for the Google-managed service agents (`gcp-sa-billing-bq-exp`, `gcp-sa-billingbudgets`). These SAs don't exist until the corresponding service is first used (BQ export enable, first budget creation), and Google auto-grants the required roles at that time. Pre-referencing failed apply with "Service account does not exist".
2. **Switched Cloud Function to explicit CloudEvent registration** via `@google-cloud/functions-framework`. The bare `exports.killSwitch = (cloudEvent) => {...}` export caused the Functions Framework to interpret the handler as a 1st-gen background signature, reading `cloudEvent.data.message.data` as undefined on every invocation. Fix: `functions.cloudEvent('killSwitch', async (cloudEvent) => {...})`.

Both changes are captured in the plan's Unit 1 and Unit 3 post-apply notes.

## Files

| Path | Purpose |
|---|---|
| `infra/gcp-billing/main.tf` | Provider, GCS backend, API enablement |
| `infra/gcp-billing/variables.tf` | Input variables + caps-map docs |
| `infra/gcp-billing/terraform.tfvars` | Billing account + host + `project_caps = {}` |
| `infra/gcp-billing/backend.tfvars` | GCS state bucket |
| `infra/gcp-billing/bigquery_export.tf` | BQ dataset for billing export |
| `infra/gcp-billing/pubsub_function.tf` | Pub/Sub topic, SA, function, allowlist env var |
| `infra/gcp-billing/budgets.tf` | Per-project `google_billing_budget` via `for_each` |
| `infra/gcp-billing/outputs.tf` | Topic, function, dataset names |
| `infra/gcp-billing/function/{index.js,package.json}` | Kill-switch handler |
| `infra/gcp-billing/README.md` | Operational playbook (test, re-enable, cap tuning) |
| `docs/plans/2026-04-14-001-feat-gcp-billing-killswitch-rollout-plan.md` | Full rollout plan, document-reviewed, Units 1–3 marked complete |

## Test plan

- [x] `terraform validate`
- [x] `terraform plan -var-file=terraform.tfvars` (empty caps → 22 adds, corrected to 20 after IAM fix)
- [x] `terraform apply` on live billing account
- [x] BigQuery export enabled; IAM auto-granted to `billing-export-bigquery@system.gserviceaccount.com`
- [x] Smoke test 1: `dry-run` name → logged as ignored ✅
- [x] Smoke test 2: missing cost/budget fields → logged as ignored ✅
- [x] Smoke test 3: below-cap (cost=1 < budget=100) → logged as no action ✅
- [x] Smoke test 4: allowlist-reject (cost=999 > budget=10, projectId not in allowlist) → refused ✅
- [x] `UpdateBillingInfo` audit log scanned — 0 calls in last hour, guards confirmed tight
- [ ] Phase 2 tests — deferred to #237 (Unit 4/5/6)

## Rollback

This PR is safe to revert even though Phase 1 is live: `terraform destroy` on this stack removes all 20 resources; no project has ever had a budget applied, so nothing's been disabled. The only permanent side-effect is the BigQuery export config in the Billing Console, which is a console-only setting.

Closes (partially — continuing in #237) whatever ticket tracks "set a spend cap on personal GCP".