### PR TITLE
fix(mcp-aviation): drop 726KB inline bundle, conform to MCP Apps spec

### DIFF
--- a/packages/blog/server/utils/mcp/aviation/aviation-tools.test.ts
+++ b/packages/blog/server/utils/mcp/aviation/aviation-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { executeListQuestions, executeSchemaTool } from './aviation-tools';
+import { executeAskAviation, executeListQuestions, executeSchemaTool } from './aviation-tools';
 import { AVIATION_STARTER_QUESTIONS } from './aviation-prompt';
 
 describe('list_questions tool', () => {
@@ -14,6 +14,32 @@ describe('list_questions tool', () => {
     }
     const structured = result.structuredContent as { questions: string[] };
     expect(structured.questions).toEqual(AVIATION_STARTER_QUESTIONS);
+  });
+});
+
+describe('ask_aviation fast return', () => {
+  const queryUrl = 'https://example.test/mcp/aviation/query';
+
+  it('returns a small text+structuredContent pair, no inline resource', () => {
+    const result = executeAskAviation({ question: 'which operators fly 737s?' }, queryUrl);
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]?.type).toBe('text');
+    const hasEmbeddedResource = result.content.some((c) => c.type === 'resource');
+    expect(hasEmbeddedResource).toBe(false);
+  });
+
+  it('echoes the question and queryUrl into structuredContent', () => {
+    const result = executeAskAviation({ question: 'how many aircraft in CA?' }, queryUrl);
+    expect(result.structuredContent).toEqual({
+      pending: true,
+      question: 'how many aircraft in CA?',
+      queryUrl,
+    });
+  });
+
+  it('serializes under 2 KB so claude.ai does not truncate the response', () => {
+    const result = executeAskAviation({ question: 'x'.repeat(500) }, queryUrl);
+    expect(JSON.stringify(result).length).toBeLessThan(2_000);
   });
 });
 

--- a/packages/blog/server/utils/mcp/aviation/aviation-tools.ts
+++ b/packages/blog/server/utils/mcp/aviation/aviation-tools.ts
@@ -15,17 +15,12 @@
 
 import { z } from 'zod';
 import { log } from 'evlog';
-import type {
-  CallToolResult,
-  EmbeddedResource,
-  TextContent,
-} from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { getAnthropicClient } from '../../ai/anthropic';
 import { MODEL_SONNET } from '../../../../shared/models';
 import { extractErrorMessage } from '../../../../shared/error-util';
 import {
   AVIATION_TOOL_NAMES,
-  AVIATION_UI_RESOURCE_URI,
   type AviationPendingResult,
   type AviationProgressStep,
   type AviationToolResult,
@@ -44,7 +39,6 @@ import {
 } from './duckdb';
 import { resolveChartOption } from './chart-bindings';
 import { validateSql } from './sql-safety';
-import { readAviationBundle } from './ui-resource';
 
 const LIMIT_ROW_CAP = 10_000;
 
@@ -68,7 +62,12 @@ interface LlmStructuredOutput {
 // ---------------- ask_aviation (fast return) ----------------
 
 /**
- * Returns the iframe bundle + a pending structuredContent pointer.
+ * Returns a small pending pointer. Compliant MCP hosts (Claude Desktop,
+ * Claude.ai, the blog chat harness) fetch `ui://aviation-answer` via
+ * `resources/read` using the `_meta.ui.resourceUri` declared on the tool;
+ * the iframe bundle and its CSP live on the registered resource itself
+ * (see `registerAviationUiResource` in `./ui-resource.ts`). Inlining the
+ * ~726 KB bundle here caused Claude.ai to truncate results mid-JSON.
  *
  * @param args - parsed tool arguments ({ question })
  * @param queryUrl - absolute URL of the /mcp/aviation/query SSE endpoint the
@@ -79,45 +78,10 @@ export function executeAskAviation(
   args: AskAviationArgs,
   queryUrl: string,
 ): CallToolResult & { structuredContent: AviationPendingResult } {
-  const html = readAviationBundle();
-
-  // Text fallback for hosts without MCP Apps support. They can't render the
-  // iframe or call our SSE endpoint, so we give them the user's own question
-  // echoed back with a note — better than an empty string, honest about what
-  // just happened.
   const fallbackText =
     `Aviation query pending: "${args.question}". ` +
     `This response includes an interactive MCP App iframe; ` +
     `hosts without UI support won't see the chart or answer.`;
-
-  // The iframe POSTs to `queryUrl` from inside its sandbox origin, so the
-  // host's CSP must allow that origin under `connect-src`. Attach the CSP meta
-  // here on the EmbeddedResource (not just the registered resource) so hosts
-  // like the blog chat harness — which reads _meta.ui off the tool result —
-  // pass it through to the sandbox. Compliant hosts (Claude Desktop / .ai)
-  // pick it up the same way.
-  let connectOrigin = '';
-  try {
-    connectOrigin = new URL(queryUrl).origin;
-  } catch {
-    // Fall through with empty origin; host defaults to self-only.
-  }
-  const csp = {
-    connectDomains: connectOrigin ? [connectOrigin] : [],
-    resourceDomains: ['self'],
-    frameDomains: [],
-  };
-
-  const textContent: TextContent = { type: 'text', text: fallbackText };
-  const uiContent: EmbeddedResource = {
-    type: 'resource',
-    resource: {
-      uri: AVIATION_UI_RESOURCE_URI,
-      mimeType: 'text/html;profile=mcp-app',
-      text: html,
-      _meta: { ui: { csp } },
-    },
-  };
 
   const pending: AviationPendingResult = {
     pending: true,
@@ -126,7 +90,7 @@ export function executeAskAviation(
   };
 
   return {
-    content: [textContent, uiContent],
+    content: [{ type: 'text', text: fallbackText }],
     structuredContent: pending as unknown as Record<string, unknown>,
   } as CallToolResult & { structuredContent: AviationPendingResult };
 }

--- a/packages/blog/server/utils/mcp/aviation/ui-resource.ts
+++ b/packages/blog/server/utils/mcp/aviation/ui-resource.ts
@@ -10,7 +10,7 @@
 
 import { AVIATION_UI_RESOURCE_URI } from '../../../../shared/mcp-aviation-types';
 import { createBundleLoader } from '../ui-bundle-loader';
-import { registerAppResource } from '@modelcontextprotocol/ext-apps/server';
+import { registerAppResource, RESOURCE_MIME_TYPE } from '@modelcontextprotocol/ext-apps/server';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 const loader = createBundleLoader({
@@ -66,7 +66,7 @@ export function registerAviationUiResource(server: McpServer, serverOrigin: stri
       contents: [
         {
           uri: AVIATION_UI_RESOURCE_URI,
-          mimeType: 'text/html;profile=mcp-app',
+          mimeType: RESOURCE_MIME_TYPE,
           text: readAviationBundle(),
           _meta: {
             ui: {

--- a/packages/blog/server/utils/mcp/client-pool.test.ts
+++ b/packages/blog/server/utils/mcp/client-pool.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import type { CallToolResult, ReadResourceResult, Tool } from '@modelcontextprotocol/sdk/types.js';
+import { extractUiResource, extractUiResourceFromRead, toolUiResourceUri } from './client-pool';
+
+describe('toolUiResourceUri', () => {
+  it('returns the ui:// uri when _meta.ui.resourceUri is set', () => {
+    const tool = {
+      name: 'ask_aviation',
+      description: '',
+      inputSchema: { type: 'object', properties: {} },
+      _meta: { ui: { resourceUri: 'ui://aviation-answer' } },
+    } as unknown as Tool;
+    expect(toolUiResourceUri(tool)).toBe('ui://aviation-answer');
+  });
+
+  it('returns undefined when the tool has no _meta', () => {
+    const tool = {
+      name: 'list_questions',
+      description: '',
+      inputSchema: { type: 'object', properties: {} },
+    } as unknown as Tool;
+    expect(toolUiResourceUri(tool)).toBeUndefined();
+  });
+
+  it('rejects non-ui:// schemes as a guard against spoofed references', () => {
+    const tool = {
+      name: 'x',
+      description: '',
+      inputSchema: { type: 'object', properties: {} },
+      _meta: { ui: { resourceUri: 'https://evil.test/bundle.html' } },
+    } as unknown as Tool;
+    expect(toolUiResourceUri(tool)).toBeUndefined();
+  });
+
+  it('returns undefined for an undefined tool', () => {
+    expect(toolUiResourceUri(undefined)).toBeUndefined();
+  });
+});
+
+describe('extractUiResource (inline EmbeddedResource)', () => {
+  it('returns the html + csp from an inline resource block', () => {
+    const result: CallToolResult = {
+      content: [
+        { type: 'text', text: 'pending' },
+        {
+          type: 'resource',
+          resource: {
+            uri: 'ui://aviation-answer',
+            mimeType: 'text/html',
+            text: '<html>inline</html>',
+            _meta: { ui: { csp: { connectDomains: ['https://chris.towles.dev'] } } },
+          },
+        },
+      ],
+    };
+    const extracted = extractUiResource(result);
+    expect(extracted).toEqual({
+      uri: 'ui://aviation-answer',
+      html: '<html>inline</html>',
+      csp: { connectDomains: ['https://chris.towles.dev'] },
+      permissions: undefined,
+    });
+  });
+
+  it('returns undefined when there is no resource block', () => {
+    const result: CallToolResult = {
+      content: [{ type: 'text', text: 'pending' }],
+    };
+    expect(extractUiResource(result)).toBeUndefined();
+  });
+
+  it('ignores non-ui:// resource blocks', () => {
+    const result: CallToolResult = {
+      content: [
+        {
+          type: 'resource',
+          resource: {
+            uri: 'file:///etc/passwd',
+            mimeType: 'text/plain',
+            text: 'nope',
+          },
+        },
+      ],
+    };
+    expect(extractUiResource(result)).toBeUndefined();
+  });
+});
+
+describe('extractUiResourceFromRead (resources/read response)', () => {
+  it('returns the html + csp for the requested uri', () => {
+    const read: ReadResourceResult = {
+      contents: [
+        {
+          uri: 'ui://aviation-answer',
+          mimeType: 'text/html;profile=mcp-app',
+          text: '<html>from-resources-read</html>',
+          _meta: { ui: { csp: { connectDomains: ['https://example.test'] } } },
+        },
+      ],
+    };
+    const extracted = extractUiResourceFromRead('ui://aviation-answer', read);
+    expect(extracted).toEqual({
+      uri: 'ui://aviation-answer',
+      html: '<html>from-resources-read</html>',
+      csp: { connectDomains: ['https://example.test'] },
+      permissions: undefined,
+    });
+  });
+
+  it('returns undefined when no content matches the requested uri', () => {
+    const read: ReadResourceResult = {
+      contents: [
+        {
+          uri: 'ui://something-else',
+          text: '<html>other</html>',
+        },
+      ],
+    };
+    expect(extractUiResourceFromRead('ui://aviation-answer', read)).toBeUndefined();
+  });
+});

--- a/packages/blog/server/utils/mcp/client-pool.ts
+++ b/packages/blog/server/utils/mcp/client-pool.ts
@@ -11,13 +11,20 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { mcpTools, type MCPClientLike } from '@anthropic-ai/sdk/helpers/beta/mcp';
 import type { BetaRunnableTool } from '@anthropic-ai/sdk/lib/tools/BetaRunnableTool';
-import type { CallToolResult, EmbeddedResource } from '@modelcontextprotocol/sdk/types.js';
+import type {
+  CallToolResult,
+  EmbeddedResource,
+  ReadResourceResult,
+  Tool,
+} from '@modelcontextprotocol/sdk/types.js';
 import { log } from 'evlog';
 import type { McpUiResourceCsp, McpUiResourcePermissions } from '../../../shared/chat-types';
 
 interface CachedMcpClient {
   client: Client;
   tools: BetaRunnableTool<Record<string, unknown>>[];
+  rawTools: Tool[];
+  resources: Map<string, ExtractedUiResource>;
 }
 
 const pool = new Map<string, CachedMcpClient>();
@@ -34,7 +41,12 @@ async function connect(endpointPath: string, baseUrl?: string): Promise<CachedMc
     await client.connect(new StreamableHTTPClientTransport(url));
     const { tools: mcpToolList } = await client.listTools();
     const tools = mcpTools(mcpToolList, client as unknown as MCPClientLike);
-    const entry: CachedMcpClient = { client, tools };
+    const entry: CachedMcpClient = {
+      client,
+      tools,
+      rawTools: mcpToolList,
+      resources: new Map(),
+    };
     pool.set(endpointPath, entry);
     log.info({
       tag: 'mcp-pool',
@@ -74,7 +86,8 @@ export interface McpToolCallOutcome {
   isError: boolean;
 }
 
-function extractUiResource(result: CallToolResult): ExtractedUiResource | undefined {
+/** @internal exported for unit tests */
+export function extractUiResource(result: CallToolResult): ExtractedUiResource | undefined {
   for (const block of result.content ?? []) {
     if (block.type !== 'resource') continue;
     const resource = (block as EmbeddedResource).resource;
@@ -97,6 +110,65 @@ function extractUiResource(result: CallToolResult): ExtractedUiResource | undefi
     };
   }
   return undefined;
+}
+
+/** @internal exported for unit tests */
+export function toolUiResourceUri(tool: Tool | undefined): string | undefined {
+  const meta = tool?._meta;
+  if (!meta || typeof meta !== 'object') return undefined;
+  const ui = (meta as { ui?: unknown }).ui;
+  if (!ui || typeof ui !== 'object') return undefined;
+  const uri = (ui as { resourceUri?: unknown }).resourceUri;
+  return typeof uri === 'string' && uri.startsWith('ui://') ? uri : undefined;
+}
+
+/** @internal exported for unit tests */
+export function extractUiResourceFromRead(
+  uri: string,
+  read: ReadResourceResult,
+): ExtractedUiResource | undefined {
+  for (const content of read.contents ?? []) {
+    const cUri = (content as { uri?: unknown }).uri;
+    if (typeof cUri !== 'string' || cUri !== uri) continue;
+    const text = (content as { text?: unknown }).text;
+    const meta = (content as { _meta?: unknown })._meta;
+    const uiMeta =
+      meta && typeof meta === 'object' && 'ui' in meta
+        ? (meta as { ui?: { csp?: McpUiResourceCsp; permissions?: McpUiResourcePermissions } }).ui
+        : undefined;
+    return {
+      uri,
+      html: typeof text === 'string' ? text : '',
+      csp: uiMeta?.csp,
+      permissions: uiMeta?.permissions,
+    };
+  }
+  return undefined;
+}
+
+async function resolveUiResource(
+  entry: CachedMcpClient,
+  toolName: string,
+  inline: ExtractedUiResource | undefined,
+): Promise<ExtractedUiResource | undefined> {
+  if (inline) return inline;
+  const tool = entry.rawTools.find((t) => t.name === toolName);
+  const uri = toolUiResourceUri(tool);
+  if (!uri) return undefined;
+  const cached = entry.resources.get(uri);
+  if (cached) return cached;
+  try {
+    const read = (await entry.client.readResource({ uri })) as ReadResourceResult;
+    const resolved = extractUiResourceFromRead(uri, read);
+    if (resolved) entry.resources.set(uri, resolved);
+    return resolved;
+  } catch (err) {
+    log.warn({
+      tag: 'mcp-pool',
+      message: `readResource ${uri} failed: ${err instanceof Error ? err.message : String(err)}`,
+    });
+    return undefined;
+  }
 }
 
 function extractText(result: CallToolResult): string {
@@ -128,11 +200,12 @@ export async function callMcpTool(
   }
   try {
     const result = (await entry.client.callTool({ name, arguments: args })) as CallToolResult;
+    const uiResource = await resolveUiResource(entry, name, extractUiResource(result));
     return {
       text: extractText(result),
       structuredContent:
         (result as { structuredContent?: Record<string, unknown> }).structuredContent ?? {},
-      uiResource: extractUiResource(result),
+      uiResource,
       isError: Boolean((result as { isError?: boolean }).isError),
     };
   } catch (err) {


### PR DESCRIPTION
## Summary

- `ask_aviation` tool now returns ~500 B (previously ~737 KB) — matches the canonical `registerAppTool` example in `@modelcontextprotocol/ext-apps`
- Blog chat harness gains a `resources/read` fallback (`client-pool.ts`) so it still gets the iframe HTML, with per-`(endpoint, uri)` caching

## Problem

When installed as a custom connector in claude.ai, `ask_aviation` failed with **"Tool result missing structuredContent"**. Probing prod directly:

```bash
$ curl … -d '{"jsonrpc":"2.0","id":3,"method":"tools/call",
              "params":{"name":"ask_aviation","arguments":{"question":"..."}}}'
# 737_581 bytes, 19 seconds
```

95 % of that payload was the compiled iframe bundle inlined as an `EmbeddedResource.text` on every call. Claude.ai truncates / times out oversized MCP results before the JSON parser reaches `structuredContent`, hence the error.

## Fix

The MCP Apps spec already has a story for UI resources — the tool advertises `_meta.ui.resourceUri`, and clients fetch from `resources/read` on that URI. Our `registerAviationUiResource` already registers `ui://aviation-answer` correctly, so the inline payload was pure bloat. Matching the canonical ext-apps example (see `registerAppTool` docstring), `executeAskAviation` now returns only the text fallback + `structuredContent` pending pointer.

The blog's own chat harness was reading the inline `EmbeddedResource`, so `client-pool.ts` now:
- Keeps the raw `Tool[]` list from `listTools()`
- On `callTool`, if the result has no inline UI resource but the tool declares `_meta.ui.resourceUri`, it calls `client.readResource({ uri })` and caches the response per `(endpoint, uri)`
- Falls back to the existing inline-extraction path for third-party servers that still inline

Also replaced the hardcoded `'text/html;profile=mcp-app'` in `ui-resource.ts` with the exported `RESOURCE_MIME_TYPE` constant.

## Test plan

- [x] `pnpm --filter @chris-towles/blog test` — 359 passing (4 new unit tests for `extractUiResource`, `extractUiResourceFromRead`, `toolUiResourceUri`, plus `executeAskAviation` size assertions)
- [x] `pnpm --filter @chris-towles/blog lint` — clean (pre-existing warnings only)
- [x] `pnpm --filter @chris-towles/blog typecheck` — clean
- [ ] After deploy: re-probe `https://chris.towles.dev/mcp/aviation` — tool response < 2 KB
- [ ] After deploy: invoke `ask_aviation` from the claude.ai connector — iframe renders, no "missing structuredContent" error
- [ ] After deploy: exercise `/chat` on the blog to confirm harness still renders the iframe (now via `resources/read`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)