### PR TITLE
fix(container): run full build script so mcp-ui/*/dist exist

### DIFF
--- a/infra/container/blog.Dockerfile
+++ b/infra/container/blog.Dockerfile
@@ -49,9 +49,13 @@ ENV NUXT_PUBLIC_GTAG_ID=$NUXT_PUBLIC_GTAG_ID
 ARG NUXT_PUBLIC_MCP_SANDBOX_URL=""
 ENV NUXT_PUBLIC_MCP_SANDBOX_URL=$NUXT_PUBLIC_MCP_SANDBOX_URL
 
-# Build the Nuxt application
+# Build the Nuxt application plus the MCP-App iframe bundles.
+# The package.json "build" script runs `build:ui-bundle` (vite builds for
+# mcp-ui/*/dist) before `nuxt build`. Using `exec nuxt build` here skipped
+# that prelude, which left mcp-ui/aviation-answer/dist absent and broke the
+# COPY steps in the runner stage.
 ENV NODE_OPTIONS="--max-old-space-size=8192"
-RUN cd /app && pnpm --filter @chris-towles/blog exec nuxt build
+RUN cd /app && pnpm --filter @chris-towles/blog run build
 
 # Production stage - use Node for runtime stability
 FROM node:24-slim AS runner
@@ -94,6 +98,8 @@ COPY --from=builder /app/packages/blog/content /app/content
 # `/app/mcp-ui/...` for any tooling that walks from a different module.
 COPY --from=builder /app/packages/blog/mcp-ui/aviation-answer/dist /mcp-ui/aviation-answer/dist
 COPY --from=builder /app/packages/blog/mcp-ui/aviation-answer/dist /app/mcp-ui/aviation-answer/dist
+COPY --from=builder /app/packages/blog/mcp-ui/echo/dist /mcp-ui/echo/dist
+COPY --from=builder /app/packages/blog/mcp-ui/echo/dist /app/mcp-ui/echo/dist
 
 # Copy loan reviewer skill files (system prompts for AI review agents)
 COPY .claude/skills/loan-the-bank/SKILL.md /app/.claude/skills/loan-the-bank/SKILL.md


### PR DESCRIPTION
## Summary

- The blog Dockerfile's builder stage called \`pnpm … exec nuxt build\`, which bypassed package.json's \`build\` script (\`build:ui-bundle && nuxt build\`). \`mcp-ui/aviation-answer/dist\` and \`mcp-ui/echo/dist\` were never produced, and the later \`COPY --from=builder\` lines failed with \`"/app/packages/blog/mcp-ui/aviation-answer/dist": not found\`.
- Every deploy since the split-tool feature landed (#239, #241) failed for this reason — including the deploy for PR #241 (merge \`06cffa5\`), which is why prod is still serving the pre-split synchronous tool response.
- Swap to \`pnpm --filter @chris-towles/blog run build\` so the UI-bundle vite builds run first, and add the missing runtime COPY for \`mcp-ui/echo/dist\` so echo doesn't 500.

## Test plan

- [x] Locally: \`rm -rf packages/blog/mcp-ui/*/dist && pnpm --filter @chris-towles/blog run build:ui-bundle\` regenerates both \`dist/index.html\` files
- [x] \`pnpm typecheck\` clean (runs via pre-commit hook)
- [ ] CI Deploy workflow runs the full \`pnpm … run build\` and container image pushes
- [ ] Post-deploy: \`curl\` probe of \`https://chris.towles.dev/mcp/aviation\` returns <2 KB for \`ask_aviation\` (currently ~737 KB from the pre-split revision)
- [ ] \`ask_aviation\` works in the claude.ai custom connector with no "missing structuredContent" error