### PR TITLE
blog: publish claude-computer-use-in-a-box

### DIFF
--- a/packages/blog/content/2.blog/20260418.claude-computer-use-in-a-box.md
+++ b/packages/blog/content/2.blog/20260418.claude-computer-use-in-a-box.md
@@ -2,7 +2,7 @@
 title: 'Claude in a Box: Trying Computer-Use on My Laptop'
 description: "Most of the apps I automate have a CLI or an API. Claude's computer-use is for the ones that don't. I spun up Anthropic's Docker demo to see what it can do."
 date: '2026-04-18'
-status: draft
+status: published
 badge:
   label: 'AI Tools'
 image:


### PR DESCRIPTION
Flip `status: draft` → `status: published` for the computer-use post so it surfaces on the public blog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)