### PR TITLE
fix(mcp-aviation): stop saying 'pending' — LLM reads it as failure

### DIFF
--- a/packages/blog/server/utils/mcp/aviation/aviation-tools.test.ts
+++ b/packages/blog/server/utils/mcp/aviation/aviation-tools.test.ts
@@ -28,6 +28,14 @@ describe('ask_aviation fast return', () => {
     expect(hasEmbeddedResource).toBe(false);
   });
 
+  it('tells the LLM the answer is already delivered (no "pending" or "trouble" phrasing)', () => {
+    const result = executeAskAviation({ question: 'test' }, queryUrl);
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
+    expect(text.toLowerCase()).not.toContain('pending');
+    expect(text.toLowerCase()).not.toContain('trouble');
+    expect(text.toLowerCase()).toMatch(/visible to the user|rendered/);
+  });
+
   it('echoes the question and queryUrl into structuredContent', () => {
     const result = executeAskAviation({ question: 'how many aircraft in CA?' }, queryUrl);
     expect(result.structuredContent).toEqual({

--- a/packages/blog/server/utils/mcp/aviation/aviation-tools.ts
+++ b/packages/blog/server/utils/mcp/aviation/aviation-tools.ts
@@ -78,10 +78,17 @@ export function executeAskAviation(
   args: AskAviationArgs,
   queryUrl: string,
 ): CallToolResult & { structuredContent: AviationPendingResult } {
-  const fallbackText =
-    `Aviation query pending: "${args.question}". ` +
-    `This response includes an interactive MCP App iframe; ` +
-    `hosts without UI support won't see the chart or answer.`;
+  // The LLM sees this text. It MUST NOT sound like an incomplete or failed
+  // call — otherwise hosts like Claude.ai's model layer read "pending" as
+  // "retry or apologize" and mark the tool call as an error. The user is
+  // already seeing the SQL, narrative, chart, and follow-ups streaming into
+  // the iframe; the model just needs to know the answer has been delivered
+  // out-of-band so it can move on.
+  const llmSummary =
+    `Rendered an interactive aviation answer for: "${args.question}". ` +
+    `The SQL, narrative explanation, ECharts visualization, and follow-up ` +
+    `suggestions are already visible to the user in the iframe — the model ` +
+    `does not need to repeat or summarize them. Proceed with the conversation.`;
 
   const pending: AviationPendingResult = {
     pending: true,
@@ -90,7 +97,7 @@ export function executeAskAviation(
   };
 
   return {
-    content: [{ type: 'text', text: fallbackText }],
+    content: [{ type: 'text', text: llmSummary }],
     structuredContent: pending as unknown as Record<string, unknown>,
   } as CallToolResult & { structuredContent: AviationPendingResult };
 }


### PR DESCRIPTION
## Summary

- In claude.ai, \`ask_aviation\` was showing warning triangles and the model said *"the aviation MCP server appears to be having trouble."* The transport + iframe were fine — the issue was the tool's text content said *"Aviation query pending: ..."*, which the model layer reads as *"not done, retry."*
- Rewrite the tool-result text to tell the model the SQL / narrative / chart / follow-ups are already visible to the user in the iframe, so the model moves on instead of retrying.
- Add a test pinning the phrasing so "pending" or "trouble" don't creep back in.

## Test plan

- [x] \`pnpm test\` — 360 passing, including the new phrasing assertion
- [x] \`pnpm typecheck\` clean (pre-commit)
- [ ] After deploy: reinvoke the claude.ai connector with *"How many aircraft are registered in California?"* — no warning triangle, iframe renders, model narrates cleanly.