### PR TITLE
fix(mcp): 404 on unknown session id so clients re-initialize

### DIFF
--- a/packages/blog/server/routes/mcp/aviation/index.ts
+++ b/packages/blog/server/routes/mcp/aviation/index.ts
@@ -106,13 +106,7 @@ function createMcpServer(serverOrigin: string): McpServer {
   return server;
 }
 
-async function getOrCreateSession(
-  sessionId: string | undefined,
-  serverOrigin: string,
-): Promise<SessionRecord> {
-  if (sessionId && sessions.has(sessionId)) {
-    return sessions.get(sessionId)!;
-  }
+async function createSession(serverOrigin: string): Promise<SessionRecord> {
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: () => randomUUID(),
     onsessioninitialized: (id: string) => {
@@ -136,7 +130,20 @@ export default defineEventHandler(async (event) => {
     const serverOrigin = (useRuntimeConfig(event).public.siteUrl as string) ?? '';
     // h3's readBody handles JSON, x-www-form-urlencoded, etc.
     const body = req.method === 'POST' ? await readBody(event) : undefined;
-    const record = await getOrCreateSession(sessionId, serverOrigin);
+
+    // Per the Streamable HTTP MCP spec: when a request carries an Mcp-Session-Id
+    // the server doesn't know (e.g. because Cloud Run rotated pods), return 404
+    // so the client re-initializes. Creating a new in-memory session here would
+    // mint a fresh ID that the client's next request won't carry, and the
+    // transport would reject every subsequent call with "Server not initialized".
+    // Claude Desktop / Claude.ai both surface that rejection as a generic tool
+    // execution error; 404 lets them transparently start a new session.
+    if (sessionId && !sessions.has(sessionId)) {
+      setResponseStatus(event, 404);
+      return { error: 'session_not_found' };
+    }
+
+    const record = sessions.get(sessionId ?? '') ?? (await createSession(serverOrigin));
     await record.transport.handleRequest(req, res, body);
   } catch (e) {
     log.error({

--- a/packages/blog/server/routes/mcp/echo/index.ts
+++ b/packages/blog/server/routes/mcp/echo/index.ts
@@ -70,10 +70,7 @@ function createMcpServer(): McpServer {
   return server;
 }
 
-async function getOrCreateSession(sessionId: string | undefined): Promise<SessionRecord> {
-  if (sessionId && sessions.has(sessionId)) {
-    return sessions.get(sessionId)!;
-  }
+async function createSession(): Promise<SessionRecord> {
   const server = createMcpServer();
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: () => randomUUID(),
@@ -95,7 +92,16 @@ export default defineEventHandler(async (event) => {
   try {
     const sessionId = getHeader(event, 'mcp-session-id');
     const body = req.method === 'POST' ? await readBody(event) : undefined;
-    const record = await getOrCreateSession(sessionId);
+
+    // See /mcp/aviation route for the rationale: return 404 when the client
+    // carries an Mcp-Session-Id we don't know (pod rotation), so it re-inits
+    // instead of getting stuck on "Server not initialized".
+    if (sessionId && !sessions.has(sessionId)) {
+      setResponseStatus(event, 404);
+      return { error: 'session_not_found' };
+    }
+
+    const record = sessions.get(sessionId ?? '') ?? (await createSession());
     await record.transport.handleRequest(req, res, body);
   } catch (e) {
     log.error({


### PR DESCRIPTION
## Summary

- Claude Desktop / Claude.ai cache their \`Mcp-Session-Id\`. Every Cloud Run pod rotation (including every prod deploy) drops our in-memory session map, and the next call with the old id used to create a new transport that then rejected every request as *"Server not initialized"* — surfaced by the LLM as *"every call is returning a generic execution error"*.
- Per the Streamable HTTP MCP spec, an unknown session id must respond **HTTP 404** so the client transparently re-initializes. Apply that to both \`/mcp/aviation\` and \`/mcp/echo\`.
- The existing "no session id at all" path still creates a fresh session for first-time initialize calls.

## Test plan

- [x] \`pnpm test\` — 360 passing
- [x] \`pnpm typecheck\` clean (pre-commit)
- [ ] After deploy: delete my desktop session / reload claude.ai, confirm \`schema\` + \`list_questions\` return real content (not "generic execution error")