### PR TITLE
fix(mcp-aviation): raise question char limit 500 -> 2000

### DIFF
--- a/packages/blog/server/routes/mcp/aviation/query.post.ts
+++ b/packages/blog/server/routes/mcp/aviation/query.post.ts
@@ -9,7 +9,7 @@
  * Claude.ai (SEP-1865 hosts don't expose an iframe until tool completion).
  *
  * Protocol:
- *   Request: JSON body `{ question: string }` (≤500 chars).
+ *   Request: JSON body `{ question: string }` (≤2000 chars).
  *   Response: `text/event-stream` with `data: <json>\n\n` events, where each
  *             payload matches `AviationQueryEvent`:
  *               { type: 'progress', step: 'planning'|'validating'|'querying'|'rendering' }

--- a/packages/blog/server/utils/mcp/aviation/aviation-tools.ts
+++ b/packages/blog/server/utils/mcp/aviation/aviation-tools.ts
@@ -43,7 +43,7 @@ import { validateSql } from './sql-safety';
 const LIMIT_ROW_CAP = 10_000;
 
 export const askAviationInputSchema = {
-  question: z.string().min(1, 'question is required').max(500, 'question must be <= 500 chars'),
+  question: z.string().min(1, 'question is required').max(2000, 'question must be <= 2000 chars'),
 };
 
 export interface AskAviationArgs {


### PR DESCRIPTION
## Summary

- Claude Desktop hit \`MCP error -32602: question must be <= 500 chars\` on a realistic cross-dataset analysis prompt. Claude's agent framing bundles enough context that 500 chars is the wrong limit for the real usage profile.
- Raise to 2000. The downstream SQL is model-generated, not user input — the cap is only there to keep tool calls bounded.

## Test plan

- [x] \`pnpm test\` — 360 passing (existing "x".repeat(500) test still green)
- [x] \`pnpm typecheck\` clean
- [ ] After deploy: re-invoke aviation tool from Claude Desktop with the same cross-dataset question — no -32602 error.

## Follow-up (not in this PR)

Bigger question surfaced in the same screenshot: *"The MCP tool keeps rendering widgets without returning raw numbers to my context."* The split-tool architecture delivers data to the iframe but not back to the LLM. Fixing that is a separate conversation — we may want to revert to a sync tool response so Claude can do follow-up analysis over the raw rows.