### PR TITLE
fix(mcp-ui): post size-changed on load, not just after ui/initialize

### DIFF
--- a/packages/blog/mcp-ui/aviation-answer/aviation-answer.ts
+++ b/packages/blog/mcp-ui/aviation-answer/aviation-answer.ts
@@ -1188,6 +1188,45 @@ if (
   typeof document !== 'undefined' &&
   document.getElementById('app') !== null
 ) {
+  // Bypass the ext-apps `autoResize` gate: the library only sends
+  // `ui/notifications/size-changed` AFTER the `ui/initialize` handshake
+  // resolves. Some hosts (observed in Claude Desktop for pending tool results)
+  // don't respond to `ui/initialize` in a timely way, leaving the iframe at 0
+  // height and invisible to the user. Post size-changed directly via
+  // `window.parent.postMessage` on load + on every resize so the host renders
+  // us regardless of whether the App handshake completes.
+  const notifySize = (): void => {
+    try {
+      const root = document.documentElement;
+      const prevHeight = root.style.height;
+      root.style.height = 'max-content';
+      const height = Math.ceil(root.getBoundingClientRect().height);
+      root.style.height = prevHeight;
+      const width = Math.ceil(window.innerWidth);
+      window.parent.postMessage(
+        {
+          jsonrpc: '2.0',
+          method: 'ui/notifications/size-changed',
+          params: { width, height },
+        },
+        '*',
+      );
+    } catch {
+      /* best-effort; postMessage rarely throws but a pinned parent origin could */
+    }
+  };
+  // Initial size ping before the App handshake fires.
+  notifySize();
+  // Observe both elements ext-apps observes, so when content arrives (loader
+  // -> chart) the host grows the iframe. The ext-apps autoResize path will
+  // additionally re-observe after connect; the duplicate notifications are
+  // harmless (host coalesces by value).
+  if (typeof ResizeObserver !== 'undefined') {
+    const ro = new ResizeObserver(() => notifySize());
+    ro.observe(document.documentElement);
+    ro.observe(document.body);
+  }
+
   const boot = createBootstrap();
   // Expose a tiny hook so the Playwright harness can deliver tool-results
   // directly when an App-level transport isn't present in the local test env.

--- a/packages/blog/mcp-ui/echo/echo.ts
+++ b/packages/blog/mcp-ui/echo/echo.ts
@@ -187,6 +187,36 @@ if (
   typeof document !== 'undefined' &&
   document.getElementById('app') !== null
 ) {
+  // See aviation-answer.ts for the rationale: send size-changed directly on
+  // load so hosts render the iframe even when the ui/initialize handshake
+  // doesn't complete (observed in Claude Desktop for pending results).
+  const notifySize = (): void => {
+    try {
+      const root = document.documentElement;
+      const prevHeight = root.style.height;
+      root.style.height = 'max-content';
+      const height = Math.ceil(root.getBoundingClientRect().height);
+      root.style.height = prevHeight;
+      const width = Math.ceil(window.innerWidth);
+      window.parent.postMessage(
+        {
+          jsonrpc: '2.0',
+          method: 'ui/notifications/size-changed',
+          params: { width, height },
+        },
+        '*',
+      );
+    } catch {
+      /* best-effort */
+    }
+  };
+  notifySize();
+  if (typeof ResizeObserver !== 'undefined') {
+    const ro = new ResizeObserver(() => notifySize());
+    ro.observe(document.documentElement);
+    ro.observe(document.body);
+  }
+
   const boot = createBootstrap();
   window.__ECHO__ = {
     handleToolResult: boot.handleToolResult,


### PR DESCRIPTION
## Summary

- ext-apps' \`App.setupSizeChangedNotifications()\` only runs after \`ui/initialize\` resolves. Some hosts (observed: Claude Desktop returning a pending-pointer tool result) never respond to \`ui/initialize\`, so the iframe stays at **0 height** and is invisible — even though its HTML + bundle load fine.
- Post \`ui/notifications/size-changed\` directly via \`window.parent.postMessage\` on load and on \`ResizeObserver\` ticks, independent of the App handshake. ext-apps' post-init autoResize still runs; duplicate notifications coalesce host-side.
- Apply to both \`mcp-ui/aviation-answer\` and \`mcp-ui/echo\`.

## Test plan

- [x] \`pnpm --filter @chris-towles/blog run build:ui-bundle\` — both bundles build clean
- [x] \`pnpm test\` — 360 passing
- [x] \`pnpm typecheck\` clean (pre-commit)
- [ ] After deploy: invoke \`ask_aviation\` in Claude Desktop, confirm the iframe renders (loader skeleton visible, then chart)
- [ ] Blog \`/chat\` still works (duplicate notifications harmless)