### PR TITLE
fix(auth): preserve redirect across OAuth round-trip

### DIFF
--- a/packages/blog/server/middleware/02-oauth-redirect.ts
+++ b/packages/blog/server/middleware/02-oauth-redirect.ts
@@ -1,0 +1,31 @@
+/**
+ * Preserve the `?redirect=...` query across an OAuth round-trip.
+ *
+ * The /auth/{provider} routes accept a `?redirect=...` query that callers
+ * use to land the user back where they started (e.g. /typing). But the
+ * OAuth provider only echoes back the registered redirect URI plus its
+ * own `code` + `state` params — our `?redirect=` is dropped between the
+ * initial bounce and the callback.
+ *
+ * Fix: on the initial hit (no `code` query — this is the user's first
+ * GET that will redirect them to the provider), stash the requested
+ * destination in a short-lived cookie. The provider handler's
+ * `onSuccess` reads the cookie and uses it as the final landing target,
+ * then clears it.
+ */
+export default defineEventHandler((event) => {
+  const url = getRequestURL(event);
+  if (!url.pathname.startsWith('/auth/')) return;
+  if (url.searchParams.has('code')) return; // callback phase — cookie already set
+
+  const redirect = url.searchParams.get('redirect');
+  if (!redirect || !redirect.startsWith('/')) return; // same-origin only
+
+  setCookie(event, 'oauth_redirect', redirect, {
+    maxAge: 60 * 10, // 10 minutes — long enough for OAuth, short enough to expire
+    sameSite: 'lax',
+    secure: !import.meta.dev,
+    path: '/',
+    httpOnly: true,
+  });
+});

--- a/packages/blog/server/routes/auth/github.get.ts
+++ b/packages/blog/server/routes/auth/github.get.ts
@@ -33,7 +33,11 @@ export default defineOAuthGitHubEventHandler({
 
     await setUserSession(event, { user });
 
-    const redirectTo = (getQuery(event).redirect as string) || '/';
+    // See google.get.ts — the OAuth callback strips our `?redirect=`
+    // query, so 02-oauth-redirect middleware stashed it in a cookie
+    // before bouncing to GitHub. Read it back here.
+    const redirectTo = getCookie(event, 'oauth_redirect') || '/';
+    deleteCookie(event, 'oauth_redirect');
     return sendRedirect(event, redirectTo);
   },
   // Optional, will return a json error and 401 status code by default

--- a/packages/blog/server/routes/auth/google.get.ts
+++ b/packages/blog/server/routes/auth/google.get.ts
@@ -33,7 +33,12 @@ export default defineOAuthGoogleEventHandler({
 
     await setUserSession(event, { user });
 
-    const redirectTo = (getQuery(event).redirect as string) || '/';
+    // The 02-oauth-redirect middleware stashed the caller's intended
+    // landing page in a cookie before bouncing to Google. Google's
+    // callback strips our `?redirect=` query, so we read from the
+    // cookie instead. Falls back to `/` for direct visits.
+    const redirectTo = getCookie(event, 'oauth_redirect') || '/';
+    deleteCookie(event, 'oauth_redirect');
     return sendRedirect(event, redirectTo);
   },
   onError(event, error) {


### PR DESCRIPTION
## Summary

`/auth/{provider}?redirect=/typing` was dropping the redirect query at the OAuth callback — Google (and GitHub) only echo back the registered redirect URI plus their own `code` + `state` params, so our `?redirect=` was lost. Result: signing in always landed on `/` regardless of where the user started.

Surfaced after #252 added a "Sign in" pill that routes through `/login?redirect=/typing` → `/auth/google?redirect=/typing`.

## Fix

- New `server/middleware/02-oauth-redirect.ts` intercepts `/auth/*` in the initial phase (no `code` query yet), stashes a same-origin `?redirect=` in an HTTP-only `oauth_redirect` cookie (10-min max-age, SameSite=Lax, Secure outside dev).
- `google.get.ts` and `github.get.ts` `onSuccess` handlers read from the cookie instead of `getQuery(event).redirect`, then delete it.
- Falls back to `/` for direct visits with no prior redirect intent.

## Verification

Hitting the initial OAuth route now sets the cookie:

\`\`\`
set-cookie: oauth_redirect=%2Ftyping; Max-Age=600; Path=/; HttpOnly; SameSite=Lax
\`\`\`

End-to-end check requires the full OAuth round-trip in a browser.

## Test plan

- [ ] CI green
- [ ] Sign in via Google from /login?redirect=/typing → lands on /typing
- [ ] Sign in via GitHub from same path → lands on /typing
- [ ] Direct visit to /auth/google (no redirect) → lands on /
- [ ] oauth_redirect cookie is cleared after the callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)