### PR TITLE
feat(typing): unify typing header with blog header + auto-refresh learners

### DIFF
--- a/packages/layers/typing/app/layouts/typing.vue
+++ b/packages/layers/typing/app/layouts/typing.vue
@@ -8,6 +8,7 @@ const { loggedIn } = useUserSession();
 // silent — the layout renders fine for anonymous users.
 const { setLearners } = useActiveLearner();
 const { data: groupsData } = await useFetch('/api/typing/groups', {
+  key: 'typing:groups',
   default: () => ({ groups: [] as Array<{ learners: Array<unknown> }> }),
   // Auth-required endpoint; ignore 401 silently.
   ignoreResponseError: true,
@@ -19,60 +20,72 @@ watchEffect(() => {
   const merged = all.flatMap((g) => g.learners as never[]);
   setLearners(merged as never);
 });
+
+const items = computed(() => [
+  {
+    label: 'Lessons',
+    to: '/typing',
+    icon: 'i-lucide-keyboard',
+    active: route.path === '/typing',
+  },
+  {
+    label: 'Topics',
+    to: '/typing/topics',
+    icon: 'i-lucide-sparkles',
+    active: route.path.startsWith('/typing/topics'),
+  },
+  {
+    label: 'Spelling',
+    to: '/typing/spelling',
+    icon: 'i-lucide-book-open',
+    active: route.path.startsWith('/typing/spelling'),
+  },
+  {
+    label: 'Progress',
+    to: '/typing/progress',
+    icon: 'i-lucide-trending-up',
+    active: route.path.startsWith('/typing/progress'),
+  },
+]);
 </script>
 
 <template>
   <div class="min-h-screen bg-slate-50 dark:bg-slate-900">
-    <header
-      v-if="!isLessonRunner"
-      class="border-b border-slate-200 bg-white px-6 py-4 dark:border-slate-700 dark:bg-slate-800"
-    >
-      <div class="mx-auto flex max-w-5xl items-center justify-between">
+    <UHeader v-if="!isLessonRunner">
+      <template #left>
         <div class="flex items-baseline gap-3">
-          <!-- Keep the blog brand visible so the kid (and parent)
-               doesn't lose site context. -->
           <LogoAndHeader />
           <span class="text-slate-400 dark:text-slate-600">/</span>
-          <NuxtLink to="/typing" class="text-xl font-semibold text-slate-900 dark:text-slate-100">
+          <NuxtLink to="/typing" class="text-xl font-semibold text-(--ui-text-highlighted)">
             Typing
           </NuxtLink>
         </div>
-        <nav class="flex items-center gap-4 text-sm">
-          <NuxtLink
-            to="/typing"
-            class="text-slate-700 hover:text-slate-900 dark:text-slate-200 dark:hover:text-white"
-          >
-            Lessons
-          </NuxtLink>
-          <NuxtLink
-            to="/typing/topics"
-            class="text-slate-700 hover:text-slate-900 dark:text-slate-200 dark:hover:text-white"
-          >
-            Topics
-          </NuxtLink>
-          <NuxtLink
-            to="/typing/spelling"
-            class="text-slate-700 hover:text-slate-900 dark:text-slate-200 dark:hover:text-white"
-          >
-            Spelling
-          </NuxtLink>
-          <NuxtLink
-            to="/typing/progress"
-            class="text-slate-700 hover:text-slate-900 dark:text-slate-200 dark:hover:text-white"
-          >
-            Progress
-          </NuxtLink>
-          <NuxtLink
-            v-if="!loggedIn"
-            to="/login?redirect=/typing"
-            class="rounded-full border border-amber-400/60 bg-amber-100/60 px-4 py-1.5 text-sm font-semibold text-amber-950 hover:bg-amber-200 dark:border-amber-500/60 dark:bg-amber-500/20 dark:text-amber-100 dark:hover:bg-amber-500/30"
-          >
-            Sign in
-          </NuxtLink>
-          <TypingLearnerSwitcher />
-        </nav>
-      </div>
-    </header>
+      </template>
+
+      <UNavigationMenu :items="items" variant="link" />
+
+      <template #right="slotProps">
+        <TypingLearnerSwitcher />
+        <UColorModeButton v-if="!loggedIn" />
+        <UserMenu
+          v-if="loggedIn"
+          :collapsed="(slotProps as Record<string, unknown>)?.collapsed as boolean | undefined"
+        />
+        <UButton
+          v-if="!loggedIn"
+          :label="(slotProps as Record<string, unknown>)?.collapsed ? '' : 'Sign in'"
+          icon="i-lucide-log-in"
+          color="neutral"
+          variant="ghost"
+          to="/login?redirect=/typing"
+        />
+      </template>
+
+      <template #body>
+        <UNavigationMenu :items="items" orientation="vertical" class="-mx-2.5" />
+      </template>
+    </UHeader>
+
     <main class="mx-auto max-w-5xl px-4 py-8 md:px-6 md:py-12">
       <slot />
     </main>

--- a/packages/layers/typing/app/layouts/typing.vue
+++ b/packages/layers/typing/app/layouts/typing.vue
@@ -53,10 +53,13 @@ const items = computed(() => [
   <div class="min-h-screen bg-slate-50 dark:bg-slate-900">
     <UHeader v-if="!isLessonRunner">
       <template #left>
-        <div class="flex items-baseline gap-3">
+        <div class="flex items-center gap-2">
           <LogoAndHeader />
-          <span class="text-slate-400 dark:text-slate-600">/</span>
-          <NuxtLink to="/typing" class="text-xl font-semibold text-(--ui-text-highlighted)">
+          <span class="text-xl text-(--ui-text-muted)">/</span>
+          <NuxtLink
+            to="/typing"
+            class="text-xl font-bold text-(--ui-text-highlighted) hover:text-(--ui-primary)"
+          >
             Typing
           </NuxtLink>
         </div>

--- a/packages/layers/typing/app/pages/typing/group/learners.vue
+++ b/packages/layers/typing/app/pages/typing/group/learners.vue
@@ -43,7 +43,7 @@ async function add() {
   });
   newName.value = '';
   newBirthYear.value = null;
-  await load();
+  await Promise.all([load(), refreshNuxtData('typing:groups')]);
 }
 
 async function bumpStage(learner: Learner, delta: number) {
@@ -53,7 +53,7 @@ async function bumpStage(learner: Learner, delta: number) {
     method: 'PUT',
     body: { currentStage: nextStage },
   });
-  await load();
+  await Promise.all([load(), refreshNuxtData('typing:groups')]);
 }
 
 await load();


### PR DESCRIPTION
## Summary

Two related typing-app polish fixes after dogfooding the new sign-in flow from #253:

- **Header consistency.** The typing layout was using a hand-rolled \`<header>\` + nav while the rest of the site uses Nuxt UI's \`UHeader\` + \`UNavigationMenu\` + \`UserMenu\`. After signing in, the typing pages showed nothing about the current user. Now the typing chrome uses the exact same components: brand on the left, nav menu in the center, color-mode + UserMenu (or Sign in button) on the right.
- **Learner list auto-refresh.** Adding or editing a learner on \`/typing/group/learners\` updated the page but not the header's "Acting as" dropdown, forcing a full page reload before the new learner could be selected. The layout's \`useFetch('/api/typing/groups')\` now carries an explicit key (\`typing:groups\`) and \`learners.vue\` calls \`refreshNuxtData('typing:groups')\` alongside its local \`load()\` after each mutation.

## Test plan

- [ ] CI green
- [ ] Sign in on \`/typing\` shows the same UserMenu (avatar/name/theme/log out) as the blog header
- [ ] Sign out / sign in flows route correctly (Sign in button + \`?redirect=/typing\` from #253)
- [ ] Add a learner on /typing/group/learners — the header's "Acting as" dropdown lists the new learner immediately, without reloading

🤖 Generated with [Claude Code](https://claude.com/claude-code)