### PR TITLE
feat(typing): slug-based group URLs + delete-learner with confirm

### DIFF
--- a/packages/blog/server/database/migrations/0012_typing_groups_slug.sql
+++ b/packages/blog/server/database/migrations/0012_typing_groups_slug.sql
@@ -1,0 +1,53 @@
+-- Add slug column to typing_groups so public URLs use a human-readable handle
+-- instead of a numeric primary key. Format: <first-6-of-creator-userId>-<slugified-name>.
+-- The integer id stays as the internal foreign-key target.
+
+ALTER TABLE "typing_groups" ADD COLUMN IF NOT EXISTS "slug" varchar(96);
+
+-- Backfill: for each existing group, compute slug from the earliest guardian's
+-- userId (first 6 chars) plus the slugified group name. Drizzle quotes the
+-- camelCase columns, so reference them as "userId" / "joinedAt".
+WITH base AS (
+  SELECT
+    g.id,
+    (
+      SELECT LEFT(m."userId", 6) || '-' || LOWER(
+        TRIM(
+          BOTH '-' FROM REGEXP_REPLACE(g.name, '[^a-zA-Z0-9]+', '-', 'g')
+        )
+      )
+      FROM "typing_group_members" m
+      WHERE m."groupId" = g.id
+      ORDER BY m."joinedAt" ASC
+      LIMIT 1
+    ) AS base_slug
+  FROM "typing_groups" g
+),
+dedup AS (
+  SELECT
+    id,
+    base_slug,
+    ROW_NUMBER() OVER (PARTITION BY base_slug ORDER BY id) AS rn
+  FROM base
+)
+UPDATE "typing_groups" g
+SET slug = CASE
+  WHEN d.rn = 1 THEN d.base_slug
+  ELSE d.base_slug || '-' || d.rn
+END
+FROM dedup d
+WHERE g.id = d.id AND d.base_slug IS NOT NULL;
+
+-- Safety net for any group that somehow has no guardian member yet.
+UPDATE "typing_groups" SET slug = 'group-' || id WHERE slug IS NULL;
+
+ALTER TABLE "typing_groups" ALTER COLUMN "slug" SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'typing_groups_slug_unique'
+  ) THEN
+    ALTER TABLE "typing_groups" ADD CONSTRAINT "typing_groups_slug_unique" UNIQUE ("slug");
+  END IF;
+END $$;

--- a/packages/blog/server/database/migrations/meta/0012_snapshot.json
+++ b/packages/blog/server/database/migrations/meta/0012_snapshot.json
@@ -1,0 +1,1818 @@
+{
+  "id": "d4e5f6a7-b8c9-0123-defa-234567890123",
+  "prevId": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "containerId": {
+          "name": "containerId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chats_user_id_idx": {
+          "name": "chats_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_chunks": {
+      "name": "document_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunkIndex": {
+          "name": "chunkIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextualContent": {
+          "name": "contextualContent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "searchVector": {
+          "name": "searchVector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_chunks_document_id_idx": {
+          "name": "document_chunks_document_id_idx",
+          "columns": [
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_chunks_chunk_index_idx": {
+          "name": "document_chunks_chunk_index_idx",
+          "columns": [
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chunkIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_chunks_documentId_documents_id_fk": {
+          "name": "document_chunks_documentId_documents_id_fk",
+          "tableFrom": "document_chunks",
+          "tableTo": "documents",
+          "columnsFrom": ["documentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_slug_idx": {
+          "name": "documents_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "documents_slug_unique": {
+          "name": "documents_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.loan_applications": {
+      "name": "loan_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "loan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'intake'"
+        },
+        "applicationData": {
+          "name": "applicationData",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "loan_applications_user_id_idx": {
+          "name": "loan_applications_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.loan_messages": {
+      "name": "loan_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "applicationId": {
+          "name": "applicationId",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "loan_messages_application_id_idx": {
+          "name": "loan_messages_application_id_idx",
+          "columns": [
+            {
+              "expression": "applicationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "loan_messages_applicationId_loan_applications_id_fk": {
+          "name": "loan_messages_applicationId_loan_applications_id_fk",
+          "tableFrom": "loan_messages",
+          "tableTo": "loan_applications",
+          "columnsFrom": ["applicationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.loan_reviews": {
+      "name": "loan_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "applicationId": {
+          "name": "applicationId",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer": {
+          "name": "reviewer",
+          "type": "reviewer",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "review_decision",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flags": {
+          "name": "flags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "loan_reviews_application_id_idx": {
+          "name": "loan_reviews_application_id_idx",
+          "columns": [
+            {
+              "expression": "applicationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "loan_reviews_applicationId_loan_applications_id_fk": {
+          "name": "loan_reviews_applicationId_loan_applications_id_fk",
+          "tableFrom": "loan_reviews",
+          "tableTo": "loan_applications",
+          "columnsFrom": ["applicationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_chat_id_idx": {
+          "name": "messages_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chatId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_chatId_chats_id_fk": {
+          "name": "messages_chatId_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_provider_id_idx": {
+          "name": "users_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.achievements": {
+      "name": "achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "childId": {
+          "name": "childId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earnedAt": {
+          "name": "earnedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "achievements_child_id_idx": {
+          "name": "achievements_child_id_idx",
+          "columns": [
+            {
+              "expression": "childId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "achievements_childId_child_profiles_id_fk": {
+          "name": "achievements_childId_child_profiles_id_fk",
+          "tableFrom": "achievements",
+          "tableTo": "child_profiles",
+          "columnsFrom": ["childId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.child_phonics_progress": {
+      "name": "child_phonics_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "childId": {
+          "name": "childId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phonicsUnitId": {
+          "name": "phonicsUnitId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'locked'"
+        },
+        "masteredAt": {
+          "name": "masteredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "child_phonics_progress_child_id_idx": {
+          "name": "child_phonics_progress_child_id_idx",
+          "columns": [
+            {
+              "expression": "childId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "child_phonics_progress_childId_child_profiles_id_fk": {
+          "name": "child_phonics_progress_childId_child_profiles_id_fk",
+          "tableFrom": "child_phonics_progress",
+          "tableTo": "child_profiles",
+          "columnsFrom": ["childId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "child_phonics_progress_phonicsUnitId_phonics_units_id_fk": {
+          "name": "child_phonics_progress_phonicsUnitId_phonics_units_id_fk",
+          "tableFrom": "child_phonics_progress",
+          "tableTo": "phonics_units",
+          "columnsFrom": ["phonicsUnitId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.child_profiles": {
+      "name": "child_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthYear": {
+          "name": "birthYear",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPhase": {
+          "name": "currentPhase",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "interests": {
+          "name": "interests",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "child_profiles_user_id_idx": {
+          "name": "child_profiles_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "child_profiles_userId_users_id_fk": {
+          "name": "child_profiles_userId_users_id_fk",
+          "tableFrom": "child_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.phonics_units": {
+      "name": "phonics_units",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orderIndex": {
+          "name": "orderIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patterns": {
+          "name": "patterns",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reading_sessions": {
+      "name": "reading_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "childId": {
+          "name": "childId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storyId": {
+          "name": "storyId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wcpm": {
+          "name": "wcpm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accuracy": {
+          "name": "accuracy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "miscues": {
+          "name": "miscues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recordingUrl": {
+          "name": "recordingUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reading_sessions_child_id_completed_idx": {
+          "name": "reading_sessions_child_id_completed_idx",
+          "columns": [
+            {
+              "expression": "childId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reading_sessions_childId_child_profiles_id_fk": {
+          "name": "reading_sessions_childId_child_profiles_id_fk",
+          "tableFrom": "reading_sessions",
+          "tableTo": "child_profiles",
+          "columnsFrom": ["childId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reading_sessions_storyId_stories_id_fk": {
+          "name": "reading_sessions_storyId_stories_id_fk",
+          "tableFrom": "reading_sessions",
+          "tableTo": "stories",
+          "columnsFrom": ["storyId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.srs_cards": {
+      "name": "srs_cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "childId": {
+          "name": "childId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cardType": {
+          "name": "cardType",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "front": {
+          "name": "front",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "back": {
+          "name": "back",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audioUrl": {
+          "name": "audioUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stability": {
+          "name": "stability",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "due": {
+          "name": "due",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastReview": {
+          "name": "lastReview",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reps": {
+          "name": "reps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lapses": {
+          "name": "lapses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "relatedPhonicsUnitId": {
+          "name": "relatedPhonicsUnitId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "srs_cards_child_id_due_idx": {
+          "name": "srs_cards_child_id_due_idx",
+          "columns": [
+            {
+              "expression": "childId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "due",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "srs_cards_childId_child_profiles_id_fk": {
+          "name": "srs_cards_childId_child_profiles_id_fk",
+          "tableFrom": "srs_cards",
+          "tableTo": "child_profiles",
+          "columnsFrom": ["childId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "srs_cards_relatedPhonicsUnitId_phonics_units_id_fk": {
+          "name": "srs_cards_relatedPhonicsUnitId_phonics_units_id_fk",
+          "tableFrom": "srs_cards",
+          "tableTo": "phonics_units",
+          "columnsFrom": ["relatedPhonicsUnitId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stories": {
+      "name": "stories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "childId": {
+          "name": "childId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "theme": {
+          "name": "theme",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "targetPatterns": {
+          "name": "targetPatterns",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "targetWords": {
+          "name": "targetWords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "decodabilityScore": {
+          "name": "decodabilityScore",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fleschKincaid": {
+          "name": "fleschKincaid",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "illustrationUrls": {
+          "name": "illustrationUrls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "aiGenerated": {
+          "name": "aiGenerated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "favorited": {
+          "name": "favorited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stories_child_id_idx": {
+          "name": "stories_child_id_idx",
+          "columns": [
+            {
+              "expression": "childId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stories_childId_child_profiles_id_fk": {
+          "name": "stories_childId_child_profiles_id_fk",
+          "tableFrom": "stories",
+          "tableTo": "child_profiles",
+          "columnsFrom": ["childId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_executions": {
+      "name": "node_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runId": {
+          "name": "runId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "promptSent": {
+          "name": "promptSent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rawResponse": {
+          "name": "rawResponse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parsedOutput": {
+          "name": "parsedOutput",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokensIn": {
+          "name": "tokensIn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokensOut": {
+          "name": "tokensOut",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latencyMs": {
+          "name": "latencyMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "node_executions_runId_workflow_runs_id_fk": {
+          "name": "node_executions_runId_workflow_runs_id_fk",
+          "tableFrom": "node_executions",
+          "tableTo": "workflow_runs",
+          "columnsFrom": ["runId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_edges": {
+      "name": "workflow_edges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edgeId": {
+          "name": "edgeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceNode": {
+          "name": "sourceNode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetNode": {
+          "name": "targetNode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceHandle": {
+          "name": "sourceHandle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetHandle": {
+          "name": "targetHandle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "animated": {
+          "name": "animated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "edgeType": {
+          "name": "edgeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'smoothstep'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_edges_workflowId_workflows_id_fk": {
+          "name": "workflow_edges_workflowId_workflows_id_fk",
+          "tableFrom": "workflow_edges",
+          "tableTo": "workflows",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_nodes": {
+      "name": "workflow_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "positionX": {
+          "name": "positionX",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "positionY": {
+          "name": "positionY",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-sonnet-4-20250514'"
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.7
+        },
+        "maxTokens": {
+          "name": "maxTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1024
+        },
+        "outputSchema": {
+          "name": "outputSchema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"type\":\"object\",\"properties\":{},\"required\":[]}'"
+        },
+        "inputMapping": {
+          "name": "inputMapping",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_nodes_workflowId_workflows_id_fk": {
+          "name": "workflow_nodes_workflowId_workflows_id_fk",
+          "tableFrom": "workflow_nodes",
+          "tableTo": "workflows",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "inputData": {
+          "name": "inputData",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outputData": {
+          "name": "outputData",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_runs_workflowId_workflows_id_fk": {
+          "name": "workflow_runs_workflowId_workflows_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "workflows",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows": {
+      "name": "workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewport": {
+          "name": "viewport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isPublished": {
+          "name": "isPublished",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.loan_status": {
+      "name": "loan_status",
+      "schema": "public",
+      "values": ["intake", "reviewing", "approved", "denied", "flagged"]
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "public",
+      "values": ["github", "google"]
+    },
+    "public.review_decision": {
+      "name": "review_decision",
+      "schema": "public",
+      "values": ["approved", "denied", "flagged"]
+    },
+    "public.reviewer": {
+      "name": "reviewer",
+      "schema": "public",
+      "values": ["the-bank", "loan-market", "background-checks"]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": ["user", "assistant"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/blog/server/database/migrations/meta/_journal.json
+++ b/packages/blog/server/database/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1778803200000,
       "tag": "0011_cutover_reading_to_typing",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1778803200001,
+      "tag": "0012_typing_groups_slug",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/blog/server/database/schema/typing.ts
+++ b/packages/blog/server/database/schema/typing.ts
@@ -21,6 +21,9 @@ import type { ErrorsByKeyMap } from '../../../shared/typing-types';
 
 export const typingGroups = pgTable('typing_groups', {
   id: serial().primaryKey(),
+  // Public URL handle: <first-6-of-creator-userId>-<slugified-name>.
+  // Integer id is kept for foreign keys; slug is what shows up in URLs.
+  slug: varchar({ length: 96 }).notNull().unique(),
   name: varchar({ length: 120 }).notNull(),
   // 'family' | 'classroom'
   kind: varchar({ length: 16 }).notNull().default('family'),

--- a/packages/blog/server/test-utils/db-helper.ts
+++ b/packages/blog/server/test-utils/db-helper.ts
@@ -149,6 +149,7 @@ export async function createTestTypingGroup(
   const [group] = await db
     .insert(tables.typingGroups)
     .values({
+      slug: `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       name: 'Test Family',
       kind: 'family',
       ...overrides,

--- a/packages/blog/shared/typing-types.ts
+++ b/packages/blog/shared/typing-types.ts
@@ -8,6 +8,8 @@ export type TypingGroupKind = 'family' | 'classroom';
 
 export type TypingGroup = {
   id: number;
+  /** Public URL handle: <first-6-of-creator-userId>-<slugified-name>. */
+  slug: string;
   name: string;
   kind: TypingGroupKind;
   createdAt: string;

--- a/packages/layers/typing/app/pages/typing/group/index.vue
+++ b/packages/layers/typing/app/pages/typing/group/index.vue
@@ -56,9 +56,9 @@ async function createFamily() {
   }
 }
 
-async function generateInvite(groupId: number) {
+async function generateInvite(groupSlug: string) {
   const result = await $fetch<{ url: string; expiresAt: string }>(
-    `/api/typing/groups/${groupId}/invite`,
+    `/api/typing/groups/${groupSlug}/invite`,
     { method: 'POST' },
   );
   inviteLink.value = result.url;
@@ -142,7 +142,7 @@ async function generateInvite(groupId: number) {
 
         <div class="flex flex-wrap items-center gap-2">
           <NuxtLink
-            :to="`/typing/group/learners?groupId=${entry.group.id}`"
+            :to="`/typing/group/learners?groupSlug=${entry.group.slug}`"
             class="rounded-lg border border-slate-300 px-3 py-1.5 text-sm hover:bg-slate-50 dark:border-slate-600 dark:hover:bg-slate-700"
           >
             Manage learners
@@ -151,7 +151,7 @@ async function generateInvite(groupId: number) {
             type="button"
             :data-testid="TEST_IDS.TYPING.GROUP_INVITE_LINK"
             class="rounded-lg bg-amber-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-amber-800"
-            @click="generateInvite(entry.group.id)"
+            @click="generateInvite(entry.group.slug)"
           >
             Generate invite link
           </button>

--- a/packages/layers/typing/app/pages/typing/group/learners.vue
+++ b/packages/layers/typing/app/pages/typing/group/learners.vue
@@ -12,7 +12,7 @@ useHead({
 });
 
 const route = useRoute();
-const groupId = computed(() => Number(route.query.groupId ?? 0));
+const groupSlug = computed(() => String(route.query.groupSlug ?? ''));
 
 const learners = ref<Learner[]>([]);
 const loading = ref(false);
@@ -20,11 +20,11 @@ const newName = ref('');
 const newBirthYear = ref<number | null>(null);
 
 async function load() {
-  if (!groupId.value) return;
+  if (!groupSlug.value) return;
   loading.value = true;
   try {
     const result = await $fetch<{ learners: Learner[] }>(
-      `/api/typing/groups/${groupId.value}/learners`,
+      `/api/typing/groups/${groupSlug.value}/learners`,
     );
     learners.value = result.learners;
   } finally {
@@ -33,8 +33,8 @@ async function load() {
 }
 
 async function add() {
-  if (!newName.value || !groupId.value) return;
-  await $fetch(`/api/typing/groups/${groupId.value}/learners`, {
+  if (!newName.value || !groupSlug.value) return;
+  await $fetch(`/api/typing/groups/${groupSlug.value}/learners`, {
     method: 'POST',
     body: {
       displayName: newName.value,
@@ -49,11 +49,46 @@ async function add() {
 async function bumpStage(learner: Learner, delta: number) {
   const nextStage = Math.max(1, Math.min(20, learner.currentStage + delta));
   if (nextStage === learner.currentStage) return;
-  await $fetch(`/api/typing/groups/${groupId.value}/learners/${learner.id}`, {
+  await $fetch(`/api/typing/groups/${groupSlug.value}/learners/${learner.id}`, {
     method: 'PUT',
     body: { currentStage: nextStage },
   });
   await Promise.all([load(), refreshNuxtData('typing:groups')]);
+}
+
+// --- Delete with type-the-name confirm ---------------------------------
+
+const deleting = ref<Learner | null>(null);
+const deleteTyped = ref('');
+const deletePending = ref(false);
+const deleteMatches = computed(() => {
+  if (!deleting.value) return false;
+  const expected = `delete ${deleting.value.displayName.trim().toLowerCase()}`;
+  return deleteTyped.value.trim().toLowerCase() === expected;
+});
+
+function openDelete(learner: Learner) {
+  deleting.value = learner;
+  deleteTyped.value = '';
+}
+
+function cancelDelete() {
+  deleting.value = null;
+  deleteTyped.value = '';
+}
+
+async function confirmDelete() {
+  if (!deleting.value || !deleteMatches.value || deletePending.value) return;
+  deletePending.value = true;
+  try {
+    await $fetch(`/api/typing/groups/${groupSlug.value}/learners/${deleting.value.id}`, {
+      method: 'DELETE',
+    });
+    cancelDelete();
+    await Promise.all([load(), refreshNuxtData('typing:groups')]);
+  } finally {
+    deletePending.value = false;
+  }
 }
 
 await load();
@@ -132,11 +167,76 @@ await load();
             >
               +
             </button>
+            <button
+              type="button"
+              class="rounded border border-rose-300 px-2 py-1 text-sm text-rose-700 hover:bg-rose-50 dark:border-rose-700 dark:text-rose-300 dark:hover:bg-rose-950/40"
+              @click="openDelete(learner)"
+            >
+              Delete
+            </button>
           </div>
         </li>
       </ul>
       <p v-else-if="loading" class="text-sm text-slate-500">Loading…</p>
       <p v-else class="text-sm text-slate-500">No learners yet — add one above.</p>
     </section>
+
+    <!-- Type-the-name confirm dialog -->
+    <div
+      v-if="deleting"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/60 p-4"
+      role="dialog"
+      aria-modal="true"
+      @click.self="cancelDelete"
+    >
+      <div
+        class="w-full max-w-md space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-2xl dark:border-slate-700 dark:bg-slate-900"
+      >
+        <header>
+          <h3 class="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            Delete this learner?
+          </h3>
+          <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">
+            This permanently removes
+            <strong class="text-slate-900 dark:text-slate-100">{{ deleting.displayName }}</strong>
+            and all of their typing progress. Type the name to confirm.
+          </p>
+        </header>
+
+        <label class="block">
+          <span
+            class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400"
+          >
+            Type: delete {{ deleting.displayName.toLowerCase() }}
+          </span>
+          <input
+            v-model="deleteTyped"
+            type="text"
+            autocomplete="off"
+            :placeholder="`delete ${deleting.displayName.toLowerCase()}`"
+            class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 font-mono text-sm dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+            @keydown.enter="confirmDelete"
+          />
+        </label>
+
+        <div class="flex justify-end gap-2">
+          <button
+            type="button"
+            class="rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-50 dark:border-slate-600 dark:hover:bg-slate-800"
+            @click="cancelDelete"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            :disabled="!deleteMatches || deletePending"
+            class="rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 disabled:cursor-not-allowed disabled:opacity-50"
+            @click="confirmDelete"
+          >
+            {{ deletePending ? 'Deleting…' : 'Delete' }}
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>

--- a/packages/layers/typing/app/pages/typing/join/[token].vue
+++ b/packages/layers/typing/app/pages/typing/join/[token].vue
@@ -20,18 +20,20 @@ const token = computed(() => String(route.params.token ?? ''));
 
 const status = ref<'idle' | 'joining' | 'done' | 'error'>('idle');
 const error = ref<string | null>(null);
-const joinedGroupId = ref<number | null>(null);
+const joinedGroupName = ref<string | null>(null);
 
 async function accept() {
   if (status.value === 'joining' || !token.value) return;
   status.value = 'joining';
   error.value = null;
   try {
-    const result = await $fetch<{ ok: true; groupId: number }>(
-      `/api/typing/groups/${token.value}/join`,
-      { method: 'POST' },
-    );
-    joinedGroupId.value = result.groupId;
+    const result = await $fetch<{
+      ok: true;
+      groupId: number;
+      groupSlug: string | null;
+      groupName: string | null;
+    }>(`/api/typing/groups/${token.value}/join`, { method: 'POST' });
+    joinedGroupName.value = result.groupName;
     status.value = 'done';
   } catch (e: unknown) {
     const err = e as { statusMessage?: string; message?: string };
@@ -55,7 +57,12 @@ async function accept() {
       v-if="status === 'done'"
       class="rounded-xl border border-emerald-300 bg-emerald-50 p-4 text-emerald-900 dark:border-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-200"
     >
-      <p>You're in! Group #{{ joinedGroupId }}.</p>
+      <p>
+        You're in!<span v-if="joinedGroupName">
+          Welcome to <strong>{{ joinedGroupName }}</strong
+          >.</span
+        >
+      </p>
       <NuxtLink
         to="/typing/group"
         class="mt-3 inline-flex rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700"

--- a/packages/layers/typing/app/utils/typing/games/tic-tac-toe.test.ts
+++ b/packages/layers/typing/app/utils/typing/games/tic-tac-toe.test.ts
@@ -58,9 +58,12 @@ describe('tic-tac-toe', () => {
     });
 
     it('weighted picks center on first move', () => {
-      // Run many trials; center should win the bulk.
+      // Statistical test: with weights [3,2,3,2,4,2,3,2,3] the center cell
+      // is sampled at ~16.7% vs ~12.5% per corner. At 500 trials a corner
+      // can occasionally edge out the center; bump the sample size so the
+      // gap is many sigma above noise.
       const tally = Array(9).fill(0);
-      for (let i = 0; i < 500; i++) {
+      for (let i = 0; i < 5000; i++) {
         const move = chooseAIMove(emptyBoard(), 'weighted');
         tally[move]++;
       }

--- a/packages/layers/typing/server/api/typing/groups/[slug].get.ts
+++ b/packages/layers/typing/server/api/typing/groups/[slug].get.ts
@@ -1,5 +1,5 @@
 /**
- * GET /api/typing/groups/:id
+ * GET /api/typing/groups/:slug
  *
  * Returns the group with its members and learners. Caller must be a guardian.
  */
@@ -12,38 +12,33 @@ import type {
   TypingGroupKind,
 } from '../../../../../../blog/shared/typing-types';
 import { requireGuardian } from '../../../utils/typing/require-guardian';
+import { findGroupBySlug } from '../../../utils/typing/groups';
 
 const paramsSchema = z.object({
-  id: z.coerce.number().int().positive(),
+  slug: z.string().min(1).max(96),
 });
 
 export default defineEventHandler(async (event) => {
-  const { id: groupId } = await getValidatedRouterParams(event, paramsSchema.parse);
-  await requireGuardian(event, { groupId });
-
-  const db = useDrizzle();
-
-  const groupRows = await db
-    .select()
-    .from(tables.typingGroups)
-    .where(eq(tables.typingGroups.id, groupId))
-    .limit(1);
-  const group = groupRows[0];
+  const { slug } = await getValidatedRouterParams(event, paramsSchema.parse);
+  const group = await findGroupBySlug(slug);
   if (!group) {
     throw createError({ statusCode: 404, statusMessage: 'Group not found' });
   }
+  await requireGuardian(event, { groupId: group.id });
 
+  const db = useDrizzle();
   const memberRows = await db
     .select()
     .from(tables.typingGroupMembers)
-    .where(eq(tables.typingGroupMembers.groupId, groupId));
+    .where(eq(tables.typingGroupMembers.groupId, group.id));
   const learnerRows = await db
     .select()
     .from(tables.typingLearners)
-    .where(eq(tables.typingLearners.groupId, groupId));
+    .where(eq(tables.typingLearners.groupId, group.id));
 
   const groupOut: TypingGroup = {
     id: group.id,
+    slug: group.slug,
     name: group.name,
     kind: group.kind as TypingGroupKind,
     createdAt: group.createdAt.toISOString(),

--- a/packages/layers/typing/server/api/typing/groups/[slug].put.ts
+++ b/packages/layers/typing/server/api/typing/groups/[slug].put.ts
@@ -1,15 +1,16 @@
 /**
- * PUT /api/typing/groups/:id
+ * PUT /api/typing/groups/:slug
  *
- * Updates name and/or kind. Guardian-only.
+ * Updates name and/or kind. Guardian-only. Slug is immutable.
  */
 import { z } from 'zod';
 import { eq } from 'drizzle-orm';
 import type { TypingGroup, TypingGroupKind } from '../../../../../../blog/shared/typing-types';
 import { requireGuardian } from '../../../utils/typing/require-guardian';
+import { findGroupBySlug } from '../../../utils/typing/groups';
 
 const paramsSchema = z.object({
-  id: z.coerce.number().int().positive(),
+  slug: z.string().min(1).max(96),
 });
 
 const bodySchema = z.object({
@@ -18,8 +19,12 @@ const bodySchema = z.object({
 });
 
 export default defineEventHandler(async (event) => {
-  const { id: groupId } = await getValidatedRouterParams(event, paramsSchema.parse);
-  await requireGuardian(event, { groupId });
+  const { slug } = await getValidatedRouterParams(event, paramsSchema.parse);
+  const group = await findGroupBySlug(slug);
+  if (!group) {
+    throw createError({ statusCode: 404, statusMessage: 'Group not found' });
+  }
+  await requireGuardian(event, { groupId: group.id });
 
   const body = await readValidatedBody(event, bodySchema.parse);
   if (!body.name && !body.kind) {
@@ -30,7 +35,7 @@ export default defineEventHandler(async (event) => {
   const [updated] = await db
     .update(tables.typingGroups)
     .set({ ...(body.name ? { name: body.name } : {}), ...(body.kind ? { kind: body.kind } : {}) })
-    .where(eq(tables.typingGroups.id, groupId))
+    .where(eq(tables.typingGroups.id, group.id))
     .returning();
 
   if (!updated) {
@@ -39,6 +44,7 @@ export default defineEventHandler(async (event) => {
 
   const out: TypingGroup = {
     id: updated.id,
+    slug: updated.slug,
     name: updated.name,
     kind: updated.kind as TypingGroupKind,
     createdAt: updated.createdAt.toISOString(),

--- a/packages/layers/typing/server/api/typing/groups/[slug]/invite.post.ts
+++ b/packages/layers/typing/server/api/typing/groups/[slug]/invite.post.ts
@@ -1,15 +1,15 @@
 /**
- * POST /api/typing/groups/:id/invite
+ * POST /api/typing/groups/:slug/invite
  *
  * Generates a single-use invite token (7-day TTL). Caller must be a guardian.
  * Returns `{ token, url, expiresAt }` so the client can copy or send.
  */
 import { z } from 'zod';
 import { requireGuardian } from '../../../../utils/typing/require-guardian';
-import { generateInviteToken } from '../../../../utils/typing/groups';
+import { findGroupBySlug, generateInviteToken } from '../../../../utils/typing/groups';
 
 const paramsSchema = z.object({
-  id: z.coerce.number().int().positive(),
+  slug: z.string().min(1).max(96),
 });
 
 const bodySchema = z.object({
@@ -19,8 +19,12 @@ const bodySchema = z.object({
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
 export default defineEventHandler(async (event) => {
-  const { id: groupId } = await getValidatedRouterParams(event, paramsSchema.parse);
-  await requireGuardian(event, { groupId });
+  const { slug } = await getValidatedRouterParams(event, paramsSchema.parse);
+  const group = await findGroupBySlug(slug);
+  if (!group) {
+    throw createError({ statusCode: 404, statusMessage: 'Group not found' });
+  }
+  await requireGuardian(event, { groupId: group.id });
 
   const body = await readValidatedBody(event, bodySchema.parse);
   const db = useDrizzle();
@@ -31,7 +35,7 @@ export default defineEventHandler(async (event) => {
   const [invite] = await db
     .insert(tables.typingGroupInvites)
     .values({
-      groupId,
+      groupId: group.id,
       token,
       email: body.email ?? null,
       expiresAt,

--- a/packages/layers/typing/server/api/typing/groups/[slug]/join.post.ts
+++ b/packages/layers/typing/server/api/typing/groups/[slug]/join.post.ts
@@ -1,10 +1,10 @@
 /**
- * POST /api/typing/groups/:id/join
+ * POST /api/typing/groups/:slug/join
  *
  * Accepts a single-use invite token and adds the calling user as a guardian
- * of the group. The :id in the URL is the invite token (we use the same
- * route shape as other group routes for symmetry — `groupId` is read from
- * the invite row, not the URL).
+ * of the group. The :slug here is actually the invite token (we use this
+ * shape for symmetry with other group routes — `groupId` is read from the
+ * invite row, not the URL).
  *
  * Token must:
  *   - exist
@@ -15,11 +15,11 @@ import { z } from 'zod';
 import { eq } from 'drizzle-orm';
 
 const paramsSchema = z.object({
-  id: z.string().min(1),
+  slug: z.string().min(1),
 });
 
 export default defineEventHandler(async (event) => {
-  const { id: token } = await getValidatedRouterParams(event, paramsSchema.parse);
+  const { slug: token } = await getValidatedRouterParams(event, paramsSchema.parse);
 
   const session = await getUserSession(event);
   const userId = session.user?.id;
@@ -60,5 +60,18 @@ export default defineEventHandler(async (event) => {
     .set({ acceptedAt: new Date(), acceptedBy: userId })
     .where(eq(tables.typingGroupInvites.id, invite.id));
 
-  return { ok: true, groupId: invite.groupId };
+  // Look up the group so the client can display name + use slug in any URL.
+  const groupRows = await db
+    .select({ slug: tables.typingGroups.slug, name: tables.typingGroups.name })
+    .from(tables.typingGroups)
+    .where(eq(tables.typingGroups.id, invite.groupId))
+    .limit(1);
+  const group = groupRows[0];
+
+  return {
+    ok: true,
+    groupId: invite.groupId,
+    groupSlug: group?.slug ?? null,
+    groupName: group?.name ?? null,
+  };
 });

--- a/packages/layers/typing/server/api/typing/groups/[slug]/learners/[learnerId].delete.ts
+++ b/packages/layers/typing/server/api/typing/groups/[slug]/learners/[learnerId].delete.ts
@@ -1,0 +1,42 @@
+/**
+ * DELETE /api/typing/groups/:slug/learners/:learnerId
+ *
+ * Permanently removes a learner from the group. Caller must be a guardian.
+ * The client gates this behind a type-the-name confirm prompt — we still
+ * verify guardianship server-side.
+ *
+ * Cascades to attempts/progress via the FK ON DELETE CASCADE rules on
+ * typing_attempts and friends.
+ */
+import { z } from 'zod';
+import { and, eq } from 'drizzle-orm';
+import { findGroupBySlug } from '../../../../../utils/typing/groups';
+import { requireGuardian } from '../../../../../utils/typing/require-guardian';
+
+const paramsSchema = z.object({
+  slug: z.string().min(1).max(96),
+  learnerId: z.coerce.number().int().positive(),
+});
+
+export default defineEventHandler(async (event) => {
+  const { slug, learnerId } = await getValidatedRouterParams(event, paramsSchema.parse);
+  const group = await findGroupBySlug(slug);
+  if (!group) {
+    throw createError({ statusCode: 404, statusMessage: 'Group not found' });
+  }
+  await requireGuardian(event, { groupId: group.id });
+
+  const db = useDrizzle();
+  const result = await db
+    .delete(tables.typingLearners)
+    .where(
+      and(eq(tables.typingLearners.id, learnerId), eq(tables.typingLearners.groupId, group.id)),
+    )
+    .returning({ id: tables.typingLearners.id });
+
+  if (result.length === 0) {
+    throw createError({ statusCode: 404, statusMessage: 'Learner not found' });
+  }
+
+  return { ok: true, deletedId: result[0]!.id };
+});

--- a/packages/layers/typing/server/api/typing/groups/[slug]/learners/[learnerId].put.ts
+++ b/packages/layers/typing/server/api/typing/groups/[slug]/learners/[learnerId].put.ts
@@ -1,5 +1,5 @@
 /**
- * PUT /api/typing/groups/:id/learners/:learnerId
+ * PUT /api/typing/groups/:slug/learners/:learnerId
  *
  * Updates a learner's display name, avatar, birth year, current stage, or
  * preferred voice. Caller must be a guardian of the group.
@@ -7,10 +7,11 @@
 import { z } from 'zod';
 import { and, eq } from 'drizzle-orm';
 import type { Learner } from '../../../../../../../../blog/shared/typing-types';
+import { findGroupBySlug } from '../../../../../utils/typing/groups';
 import { requireGuardian } from '../../../../../utils/typing/require-guardian';
 
 const paramsSchema = z.object({
-  id: z.coerce.number().int().positive(),
+  slug: z.string().min(1).max(96),
   learnerId: z.coerce.number().int().positive(),
 });
 
@@ -23,8 +24,12 @@ const bodySchema = z.object({
 });
 
 export default defineEventHandler(async (event) => {
-  const { id: groupId, learnerId } = await getValidatedRouterParams(event, paramsSchema.parse);
-  await requireGuardian(event, { groupId });
+  const { slug, learnerId } = await getValidatedRouterParams(event, paramsSchema.parse);
+  const group = await findGroupBySlug(slug);
+  if (!group) {
+    throw createError({ statusCode: 404, statusMessage: 'Group not found' });
+  }
+  await requireGuardian(event, { groupId: group.id });
 
   const body = await readValidatedBody(event, bodySchema.parse);
   const db = useDrizzle();
@@ -43,7 +48,9 @@ export default defineEventHandler(async (event) => {
   const [updated] = await db
     .update(tables.typingLearners)
     .set(set)
-    .where(and(eq(tables.typingLearners.id, learnerId), eq(tables.typingLearners.groupId, groupId)))
+    .where(
+      and(eq(tables.typingLearners.id, learnerId), eq(tables.typingLearners.groupId, group.id)),
+    )
     .returning();
   if (!updated) {
     throw createError({ statusCode: 404, statusMessage: 'Learner not found' });

--- a/packages/layers/typing/server/api/typing/groups/[slug]/learners/index.get.ts
+++ b/packages/layers/typing/server/api/typing/groups/[slug]/learners/index.get.ts
@@ -1,22 +1,26 @@
 /**
- * GET /api/typing/groups/:id/learners
+ * GET /api/typing/groups/:slug/learners
  *
  * Lists every learner in the group. Caller must be a guardian.
  */
 import { z } from 'zod';
 import type { Learner } from '../../../../../../../../blog/shared/typing-types';
-import { listGroupLearners } from '../../../../../utils/typing/groups';
+import { findGroupBySlug, listGroupLearners } from '../../../../../utils/typing/groups';
 import { requireGuardian } from '../../../../../utils/typing/require-guardian';
 
 const paramsSchema = z.object({
-  id: z.coerce.number().int().positive(),
+  slug: z.string().min(1).max(96),
 });
 
 export default defineEventHandler(async (event) => {
-  const { id: groupId } = await getValidatedRouterParams(event, paramsSchema.parse);
-  await requireGuardian(event, { groupId });
+  const { slug } = await getValidatedRouterParams(event, paramsSchema.parse);
+  const group = await findGroupBySlug(slug);
+  if (!group) {
+    throw createError({ statusCode: 404, statusMessage: 'Group not found' });
+  }
+  await requireGuardian(event, { groupId: group.id });
 
-  const rows = await listGroupLearners(groupId);
+  const rows = await listGroupLearners(group.id);
   const learners: Learner[] = rows.map((l) => ({
     id: l.id,
     groupId: l.groupId,

--- a/packages/layers/typing/server/api/typing/groups/[slug]/learners/index.post.ts
+++ b/packages/layers/typing/server/api/typing/groups/[slug]/learners/index.post.ts
@@ -1,14 +1,15 @@
 /**
- * POST /api/typing/groups/:id/learners
+ * POST /api/typing/groups/:slug/learners
  *
  * Creates a new learner in the group. Caller must be a guardian.
  */
 import { z } from 'zod';
 import type { Learner } from '../../../../../../../../blog/shared/typing-types';
+import { findGroupBySlug } from '../../../../../utils/typing/groups';
 import { requireGuardian } from '../../../../../utils/typing/require-guardian';
 
 const paramsSchema = z.object({
-  id: z.coerce.number().int().positive(),
+  slug: z.string().min(1).max(96),
 });
 
 const bodySchema = z.object({
@@ -18,15 +19,19 @@ const bodySchema = z.object({
 });
 
 export default defineEventHandler(async (event) => {
-  const { id: groupId } = await getValidatedRouterParams(event, paramsSchema.parse);
-  await requireGuardian(event, { groupId });
+  const { slug } = await getValidatedRouterParams(event, paramsSchema.parse);
+  const group = await findGroupBySlug(slug);
+  if (!group) {
+    throw createError({ statusCode: 404, statusMessage: 'Group not found' });
+  }
+  await requireGuardian(event, { groupId: group.id });
 
   const body = await readValidatedBody(event, bodySchema.parse);
   const db = useDrizzle();
   const [created] = await db
     .insert(tables.typingLearners)
     .values({
-      groupId,
+      groupId: group.id,
       displayName: body.displayName,
       birthYear: body.birthYear ?? null,
       avatarUrl: body.avatarUrl ?? null,

--- a/packages/layers/typing/server/api/typing/groups/index.get.ts
+++ b/packages/layers/typing/server/api/typing/groups/index.get.ts
@@ -27,6 +27,7 @@ export default defineEventHandler(async (event) => {
     out.push({
       group: {
         id: g.id,
+        slug: g.slug,
         name: g.name,
         kind: g.kind as TypingGroupKind,
         createdAt: g.createdAt.toISOString(),

--- a/packages/layers/typing/server/api/typing/groups/index.post.ts
+++ b/packages/layers/typing/server/api/typing/groups/index.post.ts
@@ -10,6 +10,7 @@ import type {
   TypingGroupKind,
   Learner,
 } from '../../../../../../blog/shared/typing-types';
+import { generateUniqueGroupSlug } from '../../../utils/typing/groups';
 
 const bodySchema = z.object({
   name: z.string().min(1).max(120),
@@ -27,9 +28,11 @@ export default defineEventHandler(async (event) => {
   const body = await readValidatedBody(event, bodySchema.parse);
   const db = useDrizzle();
 
+  const slug = await generateUniqueGroupSlug(userId, body.name);
+
   const [group] = await db
     .insert(tables.typingGroups)
-    .values({ name: body.name, kind: body.kind })
+    .values({ slug, name: body.name, kind: body.kind })
     .returning();
   if (!group) {
     throw createError({ statusCode: 500, statusMessage: 'Failed to create group' });
@@ -64,6 +67,7 @@ export default defineEventHandler(async (event) => {
 
   const out: TypingGroup = {
     id: group.id,
+    slug: group.slug,
     name: group.name,
     kind: group.kind as TypingGroupKind,
     createdAt: group.createdAt.toISOString(),

--- a/packages/layers/typing/server/utils/typing/groups.ts
+++ b/packages/layers/typing/server/utils/typing/groups.ts
@@ -47,6 +47,7 @@ export async function listGuardianGroups(userId: string) {
   return db
     .select({
       id: tables.typingGroups.id,
+      slug: tables.typingGroups.slug,
       name: tables.typingGroups.name,
       kind: tables.typingGroups.kind,
       createdAt: tables.typingGroups.createdAt,
@@ -58,6 +59,48 @@ export async function listGuardianGroups(userId: string) {
       eq(tables.typingGroupMembers.groupId, tables.typingGroups.id),
     )
     .where(eq(tables.typingGroupMembers.userId, userId));
+}
+
+export async function findGroupBySlug(slug: string) {
+  const db = useDrizzle();
+  const rows = await db
+    .select()
+    .from(tables.typingGroups)
+    .where(eq(tables.typingGroups.slug, slug))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+/**
+ * Build a public group slug from the creating user's id plus the group name.
+ * Format: <first-6-of-userId>-<slug(name)>. Collisions are resolved by
+ * appending `-2`, `-3`, ... via the caller's uniqueness check.
+ */
+export function buildGroupSlug(userId: string, name: string): string {
+  const prefix = userId.replace(/-/g, '').slice(0, 6).toLowerCase();
+  const namePart = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return `${prefix}-${namePart || 'group'}`;
+}
+
+export async function generateUniqueGroupSlug(userId: string, name: string): Promise<string> {
+  const db = useDrizzle();
+  const base = buildGroupSlug(userId, name);
+  let candidate = base;
+  let suffix = 2;
+  // Tiny loop: collisions are rare (same user, same group name).
+  while (true) {
+    const existing = await db
+      .select({ id: tables.typingGroups.id })
+      .from(tables.typingGroups)
+      .where(eq(tables.typingGroups.slug, candidate))
+      .limit(1);
+    if (existing.length === 0) return candidate;
+    candidate = `${base}-${suffix}`;
+    suffix += 1;
+  }
 }
 
 export async function listGroupLearners(groupId: number) {


### PR DESCRIPTION
## Summary

Two related typing-app changes:

### 1. Slug-based group URLs

User-facing URLs now expose a readable group handle instead of a numeric primary key:

Before: \`/typing/group/learners?groupId=109\`
After:  \`/typing/group/learners?groupSlug=65e255-towles-fam\`

Slug format: \`<first-6-of-creator-userId>-<slugified-name>\`. The integer id stays for foreign keys; only the URL surface changed.

- Migration 0012 adds slug VARCHAR(96) NOT NULL UNIQUE to typing_groups, with a backfill that derives slug from the earliest guardian's userId plus the slugified group name.
- \`TypingGroup\` type gains \`slug\`; API responses include it.
- Helpers: \`generateUniqueGroupSlug\`, \`findGroupBySlug\`.
- Routes renamed \`[id]\` → \`[slug]\` across \`/api/typing/groups/[slug]/...\`. Internally they resolve slug → group row.

### 2. Delete-learner with type-the-name confirm

- New \`DELETE /api/typing/groups/:slug/learners/:learnerId\` (guardian-only).
- Manage learners page shows a Delete button per row. Clicking it opens a modal that requires typing \`delete <learner name>\` verbatim before the destructive button enables.
- After delete, the layout's groups data re-fetches via \`refreshNuxtData('typing:groups')\` so the header's "Acting as" dropdown updates and falls back to anonymous if the active learner was just removed.

## Test plan

- [ ] CI green
- [ ] Existing group renders with slug in the URL: \`/typing/group/learners?groupSlug=...\`
- [ ] Create a new group → URL uses slug
- [ ] Add learner → header dropdown picks it up immediately
- [ ] Delete learner → typing the wrong name keeps confirm disabled; typing \`delete <name>\` enables it; clicking deletes and the dropdown auto-updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)