### PR TITLE
feat(typing): per-learner progress + sync currentStage to DB

### DIFF
--- a/packages/layers/typing/app/composables/useTypingProgress.ts
+++ b/packages/layers/typing/app/composables/useTypingProgress.ts
@@ -1,13 +1,14 @@
 /**
- * useTypingProgress — anonymous-first progress storage.
+ * useTypingProgress — per-learner progress storage.
  *
- * Wraps localStorage under `typing:progress:v1` for anonymous users.
+ * Each active learner gets their own localStorage namespace so switching
+ * between siblings shows distinct WPM, PRs, and current stage. The
+ * anonymous "Acting as You" user keeps the legacy unsuffixed key so any
+ * pre-existing local progress stays attached to them.
+ *
  * When the active learner is a real DB row, attempts are also POSTed to
  * `/api/typing/progress` (best-effort; localStorage is the source of
  * truth for the UI even when logged in so we never block on the network).
- *
- * Game attempts call `recordGameAttempt({ gameSlug, ... })` so attempts get
- * tagged.
  */
 import {
   MAX_STAGE,
@@ -18,6 +19,7 @@ import {
   type LocalKeyStat,
   type LocalProgress,
 } from '~~/shared/typing-types';
+import type { ActiveLearnerId } from './useActiveLearner';
 
 const TYPING_BESTS_LOCAL_STORAGE_KEY = 'typing:bests:v1';
 
@@ -30,7 +32,21 @@ export type LessonBest = {
 
 type LessonBestMap = Record<string, LessonBest>;
 
-let bestsCache: LessonBestMap | null = null;
+function progressKeyFor(id: ActiveLearnerId): string {
+  return id === 'anon'
+    ? TYPING_PROGRESS_LOCAL_STORAGE_KEY
+    : `${TYPING_PROGRESS_LOCAL_STORAGE_KEY}:learner:${id}`;
+}
+
+function bestsKeyFor(id: ActiveLearnerId): string {
+  return id === 'anon'
+    ? TYPING_BESTS_LOCAL_STORAGE_KEY
+    : `${TYPING_BESTS_LOCAL_STORAGE_KEY}:learner:${id}`;
+}
+
+// Per-learner bests cache keyed by full storage key. A naive module-level
+// cache would leak one learner's PRs into another.
+const bestsCacheByKey = new Map<string, LessonBestMap>();
 
 function isLessonBest(val: unknown): val is LessonBest {
   if (!val || typeof val !== 'object') return false;
@@ -43,47 +59,46 @@ function isLessonBest(val: unknown): val is LessonBest {
   );
 }
 
-function readBests(): LessonBestMap {
-  if (bestsCache) return bestsCache;
+function readBests(id: ActiveLearnerId): LessonBestMap {
+  const key = bestsKeyFor(id);
+  const cached = bestsCacheByKey.get(key);
+  if (cached) return cached;
   if (typeof localStorage === 'undefined') return {};
+  let out: LessonBestMap = {};
   try {
-    const raw = localStorage.getItem(TYPING_BESTS_LOCAL_STORAGE_KEY);
-    if (!raw || typeof raw !== 'string') {
-      bestsCache = {};
-      return bestsCache;
+    const raw = localStorage.getItem(key);
+    if (raw && typeof raw === 'string') {
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        // Drop any entries that don't match the LessonBest shape — guards
+        // against half-written rows or older schema leaking in.
+        for (const [slug, entry] of Object.entries(parsed as Record<string, unknown>)) {
+          if (isLessonBest(entry)) out[slug] = entry;
+        }
+      }
     }
-    const parsed: unknown = JSON.parse(raw);
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      bestsCache = {};
-      return bestsCache;
-    }
-    // Drop any entries that don't match the LessonBest shape — guards
-    // against half-written rows or older schema leaking in.
-    const out: LessonBestMap = {};
-    for (const [slug, entry] of Object.entries(parsed as Record<string, unknown>)) {
-      if (isLessonBest(entry)) out[slug] = entry;
-    }
-    bestsCache = out;
   } catch {
-    bestsCache = {};
+    out = {};
   }
-  return bestsCache;
+  bestsCacheByKey.set(key, out);
+  return out;
 }
 
-function writeBests(b: LessonBestMap) {
-  bestsCache = b;
+function writeBests(id: ActiveLearnerId, b: LessonBestMap) {
+  const key = bestsKeyFor(id);
+  bestsCacheByKey.set(key, b);
   if (typeof localStorage === 'undefined') return;
   try {
-    localStorage.setItem(TYPING_BESTS_LOCAL_STORAGE_KEY, JSON.stringify(b));
+    localStorage.setItem(key, JSON.stringify(b));
   } catch {
     // best-effort; lessons still work without PR tracking.
   }
 }
 
-function readStorage(): LocalProgress {
+function readStorage(id: ActiveLearnerId): LocalProgress {
   if (typeof localStorage === 'undefined') return emptyLocalProgress();
   try {
-    const raw = localStorage.getItem(TYPING_PROGRESS_LOCAL_STORAGE_KEY);
+    const raw = localStorage.getItem(progressKeyFor(id));
     if (!raw) return emptyLocalProgress();
     const parsed = JSON.parse(raw) as Partial<LocalProgress>;
     if (parsed.schemaVersion !== 1) return emptyLocalProgress();
@@ -98,12 +113,12 @@ function readStorage(): LocalProgress {
   }
 }
 
-function writeStorage(p: LocalProgress) {
+function writeStorage(id: ActiveLearnerId, p: LocalProgress) {
   if (typeof localStorage === 'undefined') return;
   try {
-    localStorage.setItem(TYPING_PROGRESS_LOCAL_STORAGE_KEY, JSON.stringify(p));
+    localStorage.setItem(progressKeyFor(id), JSON.stringify(p));
   } catch {
-    // Ignore quota errors — anonymous progress is best-effort.
+    // Ignore quota errors — progress writes are best-effort.
   }
 }
 
@@ -157,22 +172,43 @@ export type UseTypingProgress = {
 };
 
 export function useTypingProgress(): UseTypingProgress {
-  const progress = useState<LocalProgress>('typing:progress', () => readStorage());
+  const { activeLearnerId, active } = useActiveLearner();
 
-  // Re-read on mount in case localStorage was updated by another tab.
+  const progress = useState<LocalProgress>('typing:progress', () =>
+    readStorage(activeLearnerId.value),
+  );
+
+  // Re-read whenever the active learner changes so switching siblings
+  // shows that learner's distinct attempts and current stage. For a
+  // real learner we also seed currentStage from the server-tracked
+  // value so a fresh device respects progress made elsewhere; the kid
+  // is never demoted (local may be ahead from offline practice).
   if (import.meta.client) {
-    progress.value = readStorage();
+    watch(
+      activeLearnerId,
+      (id) => {
+        const next = readStorage(id);
+        if (id !== 'anon' && active.value) {
+          next.currentStage = Math.max(next.currentStage, active.value.currentStage);
+        }
+        progress.value = next;
+      },
+      { immediate: true },
+    );
   }
 
-  // Cross-tab sync — when another tab writes to typing:progress:v1 or
-  // typing:bests:v1, invalidate our caches and refresh reactive state so
-  // the kid sees their PR / current-stage update without a reload.
+  // Cross-tab sync — when another tab writes to either keyed slot for
+  // the current learner, invalidate our caches and refresh reactive
+  // state so the kid sees their PR / current-stage update without a
+  // reload.
   if (import.meta.client) {
     const onStorage = (e: StorageEvent) => {
-      if (e.key === TYPING_BESTS_LOCAL_STORAGE_KEY) {
-        bestsCache = null;
-      } else if (e.key === TYPING_PROGRESS_LOCAL_STORAGE_KEY) {
-        progress.value = readStorage();
+      const id = activeLearnerId.value;
+      if (!e.key) return;
+      if (e.key === bestsKeyFor(id)) {
+        bestsCacheByKey.delete(e.key);
+      } else if (e.key === progressKeyFor(id)) {
+        progress.value = readStorage(id);
       }
     };
     window.addEventListener('storage', onStorage);
@@ -180,8 +216,6 @@ export function useTypingProgress(): UseTypingProgress {
       window.removeEventListener('storage', onStorage);
     });
   }
-
-  const { activeLearnerId } = useActiveLearner();
 
   type ServerExtras = {
     spellingListId?: number | null;
@@ -246,9 +280,21 @@ export function useTypingProgress(): UseTypingProgress {
       attempts: nextAttempts,
       keyStats: mergeKeyStats(progress.value.keyStats, stats),
     };
+    const id = activeLearnerId.value;
     progress.value = next;
-    writeStorage(next);
+    writeStorage(id, next);
     maybePushToServer(attempt, stats, extras);
+    // If a real learner just cleared the mastery gate, persist the new
+    // stage on the learner row so the next sign-in / device respects it.
+    if (nextStage > previousStage && id !== 'anon') {
+      void $fetch(`/api/typing/learners/${id}/stage`, {
+        method: 'PUT',
+        body: { currentStage: nextStage },
+      }).catch(() => {
+        // Network failure: localStorage still has the new stage. The
+        // next stage advance or explicit setCurrentStage will retry.
+      });
+    }
 
     return {
       stageAdvanced: nextStage > previousStage,
@@ -282,26 +328,38 @@ export function useTypingProgress(): UseTypingProgress {
   }
 
   function setCurrentStage(stage: number) {
-    const next = { ...progress.value, currentStage: Math.max(1, Math.min(MAX_STAGE, stage)) };
+    const clamped = Math.max(1, Math.min(MAX_STAGE, stage));
+    const id = activeLearnerId.value;
+    const next = { ...progress.value, currentStage: clamped };
     progress.value = next;
-    writeStorage(next);
+    writeStorage(id, next);
+    if (id !== 'anon') {
+      void $fetch(`/api/typing/learners/${id}/stage`, {
+        method: 'PUT',
+        body: { currentStage: clamped },
+      }).catch(() => {
+        // best-effort
+      });
+    }
   }
 
   function reset() {
+    const id = activeLearnerId.value;
     const next = emptyLocalProgress();
     progress.value = next;
-    writeStorage(next);
+    writeStorage(id, next);
   }
 
   function getLessonBest(slug: string): LessonBest | null {
-    return readBests()[slug] ?? null;
+    return readBests(activeLearnerId.value)[slug] ?? null;
   }
 
   function recordLessonBest(
     slug: string,
     attempt: { wpm: number; accuracy: number; durationMs: number },
   ): { isNewBest: boolean; previous: LessonBest | null } {
-    const bests = readBests();
+    const id = activeLearnerId.value;
+    const bests = readBests(id);
     const previous = bests[slug] ?? null;
     const isNewBest = previous === null || attempt.wpm > previous.wpm;
     if (isNewBest) {
@@ -311,7 +369,7 @@ export function useTypingProgress(): UseTypingProgress {
         durationMs: attempt.durationMs,
         recordedAt: new Date().toISOString(),
       };
-      writeBests(bests);
+      writeBests(id, bests);
     }
     return { isNewBest, previous };
   }

--- a/packages/layers/typing/server/api/typing/learners/[learnerId]/stage.put.ts
+++ b/packages/layers/typing/server/api/typing/learners/[learnerId]/stage.put.ts
@@ -1,0 +1,54 @@
+/**
+ * PUT /api/typing/learners/:learnerId/stage
+ *
+ * Pushes the kid's currentStage back to typingLearners so progress is
+ * durable across devices. Caller must be a guardian of the learner.
+ *
+ * Direct path (vs PUT /api/typing/groups/:slug/learners/:learnerId) so the
+ * client doesn't need to know the group's slug — useTypingProgress only
+ * has the learnerId in hand.
+ */
+import { z } from 'zod';
+import { eq } from 'drizzle-orm';
+import { MAX_STAGE } from '../../../../../../../blog/shared/typing-types';
+import { requireGuardian } from '../../../../utils/typing/require-guardian';
+
+const paramsSchema = z.object({
+  learnerId: z.coerce.number().int().positive(),
+});
+
+const bodySchema = z.object({
+  currentStage: z.number().int().min(1).max(MAX_STAGE),
+});
+
+export default defineEventHandler(async (event) => {
+  const { learnerId } = await getValidatedRouterParams(event, paramsSchema.parse);
+  await requireGuardian(event, { learnerId });
+
+  const body = await readValidatedBody(event, bodySchema.parse);
+  const db = useDrizzle();
+
+  // Don't demote — only push forward. A device may briefly lag behind
+  // the server's record; we never want a stale local value to undo a
+  // stage already unlocked on another device.
+  const existing = await db
+    .select({ currentStage: tables.typingLearners.currentStage })
+    .from(tables.typingLearners)
+    .where(eq(tables.typingLearners.id, learnerId))
+    .limit(1);
+  const prev = existing[0];
+  if (!prev) {
+    throw createError({ statusCode: 404, statusMessage: 'Learner not found' });
+  }
+  if (body.currentStage <= prev.currentStage) {
+    return { currentStage: prev.currentStage, changed: false };
+  }
+
+  const [updated] = await db
+    .update(tables.typingLearners)
+    .set({ currentStage: body.currentStage })
+    .where(eq(tables.typingLearners.id, learnerId))
+    .returning({ currentStage: tables.typingLearners.currentStage });
+
+  return { currentStage: updated?.currentStage ?? body.currentStage, changed: true };
+});


### PR DESCRIPTION
## Summary

Dogfooding bug: switching from "You (anonymous)" to a real learner (Abby, Logan) showed the same WPM and lesson PRs as the anonymous user. Root cause: progress + bests were stored in a single localStorage namespace.

This PR scopes localStorage per active learner and pushes stage advances back to the DB so progress survives across devices.

## Changes

**Per-learner localStorage:**

- Keys gain a \`:learner:<id>\` suffix when the active learner is a real DB row. Anonymous keeps the legacy unsuffixed key so existing local progress stays attached to "You (anonymous)".
- The bests cache is now keyed per learner so it can't leak across switches.
- \`useTypingProgress\` watches \`activeLearnerId\` and re-reads on every change. Cross-tab \`storage\` events only fire when the changed key matches the current learner.

**Server sync (write-through):**

- New \`PUT /api/typing/learners/:learnerId/stage\`. Guardian-only. Never demotes — only pushes forward — so a stale local value can't undo a stage already unlocked from another device.
- \`recordAttempt\` fires the PUT when a stage advance happens for a real learner. \`setCurrentStage\` fires it too.

**Hydration on learner switch:**

- When switching to a real learner, seed \`currentStage\` from the learner row (already returned by \`/api/typing/groups\`). Take \`max(local, server)\` so offline practice isn't lost.

## Verified in browser

- Acting as "You (anonymous)" → 19 wpm + 23 wpm PRs on the Letters / Sentence cards (existing data).
- Switch to Abby → PRs disappear, "You're on stage 1", empty per-learner localStorage namespace.
- Switch back to anonymous → original PRs return.
- \`PUT /api/typing/learners/74/stage\` with \`{ currentStage: 1 }\` returns \`{ changed: false, currentStage: 1 }\` — the never-demote guard works.

## Follow-up not in this PR

Lesson bests still live only in localStorage. To make them DB-durable I need a \`lessonSlug\` column on \`typing_attempts\` plus a derive-bests endpoint. Tracked as a separate task — the immediate "Logan sees Chris's WPM" symptom is fixed by this PR.

## Test plan

- [ ] CI green
- [ ] Existing unit tests pass (anonymous test mock still uses the legacy key path)
- [ ] Acting as a real learner → empty PRs / fresh stage
- [ ] Acting as anonymous → existing local PRs visible
- [ ] Stage advance during a lesson updates \`typingLearners.currentStage\` server-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)