### PR TITLE
fix(typing): groups SSR-empty bug + add delete-group + invite polish

### DIFF
--- a/packages/layers/typing/app/layouts/typing.vue
+++ b/packages/layers/typing/app/layouts/typing.vue
@@ -10,8 +10,11 @@ const { setLearners } = useActiveLearner();
 const { data: groupsData } = await useFetch('/api/typing/groups', {
   key: 'typing:groups',
   default: () => ({ groups: [] as Array<{ learners: Array<unknown> }> }),
-  // Auth-required endpoint; ignore 401 silently.
+  // Auth-required endpoint; ignore 401 silently. Skip SSR — the session
+  // cookie isn't attached to the internal fetch during SSR, so the
+  // request would 401 and the page would hydrate with empty groups.
   ignoreResponseError: true,
+  server: false,
 });
 watchEffect(() => {
   const all = groupsData.value?.groups ?? [];

--- a/packages/layers/typing/app/pages/typing/group/index.vue
+++ b/packages/layers/typing/app/pages/typing/group/index.vue
@@ -16,11 +16,18 @@ useHead({
   ],
 });
 
-const { data, refresh, error } = await useFetch<{
+// Auth-required endpoint — load client-side only so the session cookie is
+// always attached. Without server:false, SSR runs the request with no
+// session cookie and the page renders the empty-state even when the
+// user has groups. Key is shared with the layout so a refresh from any
+// mutating action also refreshes the header switcher.
+const { data, refresh, error, pending } = await useFetch<{
   groups: Array<{ group: TypingGroup; learners: Learner[] }>;
 }>('/api/typing/groups', {
+  key: 'typing:groups',
   default: () => ({ groups: [] }),
   ignoreResponseError: true,
+  server: false,
 });
 
 const isUnauthed = computed(() => {
@@ -35,10 +42,12 @@ const newLearnerName = ref('');
 const inviteLink = ref<string | null>(null);
 const inviteExpires = ref<string | null>(null);
 const creating = ref(false);
+const formError = ref<string | null>(null);
 
 async function createFamily() {
   if (!newGroupName.value || creating.value) return;
   creating.value = true;
+  formError.value = null;
   try {
     await $fetch('/api/typing/groups', {
       method: 'POST',
@@ -50,19 +59,88 @@ async function createFamily() {
     });
     newGroupName.value = '';
     newLearnerName.value = '';
+    // refresh() updates this page's data; the layout shares the same
+    // 'typing:groups' key so the header switcher picks up the new
+    // group + learner immediately too.
     await refresh();
+  } catch (e: unknown) {
+    const err = e as { statusMessage?: string; message?: string };
+    formError.value = err.statusMessage ?? err.message ?? 'Failed to create family';
   } finally {
     creating.value = false;
   }
 }
 
-async function generateInvite(groupSlug: string) {
-  const result = await $fetch<{ url: string; expiresAt: string }>(
-    `/api/typing/groups/${groupSlug}/invite`,
-    { method: 'POST' },
-  );
-  inviteLink.value = result.url;
-  inviteExpires.value = result.expiresAt;
+const invitePending = ref<number | null>(null);
+async function generateInvite(group: TypingGroup) {
+  if (invitePending.value === group.id) return;
+  invitePending.value = group.id;
+  formError.value = null;
+  try {
+    const result = await $fetch<{ url: string; expiresAt: string }>(
+      `/api/typing/groups/${group.slug}/invite`,
+      { method: 'POST', body: {} },
+    );
+    // Make the link copy-able with the full origin baked in.
+    const origin =
+      typeof window !== 'undefined' && window.location?.origin ? window.location.origin : '';
+    inviteLink.value = origin ? `${origin}${result.url}` : result.url;
+    inviteExpires.value = result.expiresAt;
+  } catch (e: unknown) {
+    const err = e as { statusMessage?: string; message?: string };
+    formError.value = err.statusMessage ?? err.message ?? 'Failed to generate invite';
+  } finally {
+    invitePending.value = null;
+  }
+}
+
+async function copyInvite() {
+  if (!inviteLink.value) return;
+  try {
+    await navigator.clipboard.writeText(inviteLink.value);
+  } catch {
+    // Clipboard may be blocked; user can still copy by selecting.
+  }
+}
+
+// --- Delete-group with type-the-name confirm --------------------------
+
+const deletingGroup = ref<TypingGroup | null>(null);
+const deleteTyped = ref('');
+const deletePending = ref(false);
+const deleteMatches = computed(() => {
+  if (!deletingGroup.value) return false;
+  const expected = `delete ${deletingGroup.value.name.trim().toLowerCase()}`;
+  return deleteTyped.value.trim().toLowerCase() === expected;
+});
+
+function openDeleteGroup(group: TypingGroup) {
+  deletingGroup.value = group;
+  deleteTyped.value = '';
+  formError.value = null;
+}
+
+function cancelDeleteGroup() {
+  deletingGroup.value = null;
+  deleteTyped.value = '';
+}
+
+async function confirmDeleteGroup() {
+  if (!deletingGroup.value || !deleteMatches.value || deletePending.value) return;
+  deletePending.value = true;
+  formError.value = null;
+  try {
+    await $fetch(`/api/typing/groups/${deletingGroup.value.slug}`, { method: 'DELETE' });
+    cancelDeleteGroup();
+    inviteLink.value = null;
+    inviteExpires.value = null;
+    await refresh();
+  } catch (e: unknown) {
+    const err = e as { statusMessage?: string; message?: string };
+    formError.value = err.statusMessage ?? err.message ?? 'Failed to delete group';
+  } finally {
+    deletePending.value = false;
+  }
 }
 </script>
 
@@ -74,6 +152,14 @@ async function generateInvite(groupSlug: string) {
         Families and classrooms — manage learners and invite other guardians.
       </p>
     </header>
+
+    <p
+      v-if="formError"
+      class="rounded-lg border border-rose-300 bg-rose-50 px-4 py-2 text-sm text-rose-800 dark:border-rose-700 dark:bg-rose-950/40 dark:text-rose-200"
+      role="alert"
+    >
+      {{ formError }}
+    </p>
 
     <section
       v-if="isUnauthed"
@@ -87,6 +173,8 @@ async function generateInvite(groupSlug: string) {
         Sign in
       </NuxtLink>
     </section>
+
+    <p v-else-if="pending" class="text-sm text-slate-500">Loading your groups…</p>
 
     <section v-else-if="groups.length === 0" class="space-y-3">
       <h2 class="text-xl font-semibold text-slate-900 dark:text-slate-100">Create your family</h2>
@@ -150,10 +238,18 @@ async function generateInvite(groupSlug: string) {
           <button
             type="button"
             :data-testid="TEST_IDS.TYPING.GROUP_INVITE_LINK"
-            class="rounded-lg bg-amber-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-amber-800"
-            @click="generateInvite(entry.group.slug)"
+            :disabled="invitePending === entry.group.id"
+            class="rounded-lg bg-amber-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-amber-800 disabled:opacity-50"
+            @click="generateInvite(entry.group)"
           >
-            Generate invite link
+            {{ invitePending === entry.group.id ? 'Generating…' : 'Generate invite link' }}
+          </button>
+          <button
+            type="button"
+            class="rounded-lg border border-rose-300 px-3 py-1.5 text-sm text-rose-700 hover:bg-rose-50 dark:border-rose-700 dark:text-rose-300 dark:hover:bg-rose-950/40"
+            @click="openDeleteGroup(entry.group)"
+          >
+            Delete group
           </button>
         </div>
       </article>
@@ -163,9 +259,79 @@ async function generateInvite(groupSlug: string) {
         class="rounded-xl border border-emerald-300 bg-emerald-50 p-4 text-sm text-emerald-900 dark:border-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-200"
       >
         <p class="mb-2 font-semibold">Invite link generated</p>
-        <p class="font-mono text-xs">{{ inviteLink }}</p>
+        <p class="break-all font-mono text-xs">{{ inviteLink }}</p>
         <p class="mt-1 text-xs">Expires {{ inviteExpires }}</p>
+        <button
+          type="button"
+          class="mt-2 rounded-lg bg-emerald-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-800"
+          @click="copyInvite"
+        >
+          Copy link
+        </button>
       </div>
     </section>
+
+    <!-- Delete-group confirm dialog (type the name) -->
+    <div
+      v-if="deletingGroup"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/60 p-4"
+      role="dialog"
+      aria-modal="true"
+      :aria-labelledby="`delete-group-${deletingGroup.id}-title`"
+      @click.self="cancelDeleteGroup"
+    >
+      <div
+        class="w-full max-w-md space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-2xl dark:border-slate-700 dark:bg-slate-900"
+      >
+        <header>
+          <h3
+            :id="`delete-group-${deletingGroup.id}-title`"
+            class="text-lg font-semibold text-slate-900 dark:text-slate-100"
+          >
+            Delete this group?
+          </h3>
+          <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">
+            This permanently removes
+            <strong class="text-slate-900 dark:text-slate-100">{{ deletingGroup.name }}</strong>
+            along with every learner, attempt, invite, and guardian membership in it. Type the group
+            name to confirm.
+          </p>
+        </header>
+
+        <label class="block">
+          <span
+            class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400"
+          >
+            Type: delete {{ deletingGroup.name.toLowerCase() }}
+          </span>
+          <input
+            v-model="deleteTyped"
+            type="text"
+            autocomplete="off"
+            :placeholder="`delete ${deletingGroup.name.toLowerCase()}`"
+            class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 font-mono text-sm dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+            @keydown.enter="confirmDeleteGroup"
+          />
+        </label>
+
+        <div class="flex justify-end gap-2">
+          <button
+            type="button"
+            class="rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-50 dark:border-slate-600 dark:hover:bg-slate-800"
+            @click="cancelDeleteGroup"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            :disabled="!deleteMatches || deletePending"
+            class="rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 disabled:cursor-not-allowed disabled:opacity-50"
+            @click="confirmDeleteGroup"
+          >
+            {{ deletePending ? 'Deleting…' : 'Delete group' }}
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>

--- a/packages/layers/typing/app/pages/typing/group/learners.vue
+++ b/packages/layers/typing/app/pages/typing/group/learners.vue
@@ -14,23 +14,28 @@ useHead({
 const route = useRoute();
 const groupSlug = computed(() => String(route.query.groupSlug ?? ''));
 
-const learners = ref<Learner[]>([]);
-const loading = ref(false);
 const newName = ref('');
 const newBirthYear = ref<number | null>(null);
 
-async function load() {
-  if (!groupSlug.value) return;
-  loading.value = true;
-  try {
-    const result = await $fetch<{ learners: Learner[] }>(
-      `/api/typing/groups/${groupSlug.value}/learners`,
-    );
-    learners.value = result.learners;
-  } finally {
-    loading.value = false;
-  }
-}
+// useFetch keyed by slug, client-only — auth cookie isn't forwarded
+// during SSR for $fetch/useFetch internal calls in this setup. Tying
+// `key` to the slug means switching groups re-runs the fetch.
+const {
+  data: learnersData,
+  refresh: refreshLearners,
+  pending: loading,
+} = await useFetch<{ learners: Learner[] }>(
+  () => `/api/typing/groups/${groupSlug.value}/learners`,
+  {
+    key: () => `typing:learners:${groupSlug.value}`,
+    default: () => ({ learners: [] as Learner[] }),
+    ignoreResponseError: true,
+    server: false,
+    watch: [groupSlug],
+    immediate: true,
+  },
+);
+const learners = computed(() => learnersData.value?.learners ?? []);
 
 async function add() {
   if (!newName.value || !groupSlug.value) return;
@@ -43,7 +48,7 @@ async function add() {
   });
   newName.value = '';
   newBirthYear.value = null;
-  await Promise.all([load(), refreshNuxtData('typing:groups')]);
+  await Promise.all([refreshLearners(), refreshNuxtData('typing:groups')]);
 }
 
 async function bumpStage(learner: Learner, delta: number) {
@@ -53,7 +58,7 @@ async function bumpStage(learner: Learner, delta: number) {
     method: 'PUT',
     body: { currentStage: nextStage },
   });
-  await Promise.all([load(), refreshNuxtData('typing:groups')]);
+  await Promise.all([refreshLearners(), refreshNuxtData('typing:groups')]);
 }
 
 // --- Delete with type-the-name confirm ---------------------------------
@@ -85,13 +90,11 @@ async function confirmDelete() {
       method: 'DELETE',
     });
     cancelDelete();
-    await Promise.all([load(), refreshNuxtData('typing:groups')]);
+    await Promise.all([refreshLearners(), refreshNuxtData('typing:groups')]);
   } finally {
     deletePending.value = false;
   }
 }
-
-await load();
 </script>
 
 <template>

--- a/packages/layers/typing/server/api/typing/groups/[slug].delete.ts
+++ b/packages/layers/typing/server/api/typing/groups/[slug].delete.ts
@@ -1,0 +1,38 @@
+/**
+ * DELETE /api/typing/groups/:slug
+ *
+ * Permanently removes a group and all of its learners, members, invites,
+ * attempts (via FK ON DELETE CASCADE). Caller must be a guardian.
+ *
+ * Type-the-name confirm is enforced client-side. Server still verifies
+ * guardianship so the delete is safe even if the confirm is bypassed.
+ */
+import { z } from 'zod';
+import { eq } from 'drizzle-orm';
+import { findGroupBySlug } from '../../../utils/typing/groups';
+import { requireGuardian } from '../../../utils/typing/require-guardian';
+
+const paramsSchema = z.object({
+  slug: z.string().min(1).max(96),
+});
+
+export default defineEventHandler(async (event) => {
+  const { slug } = await getValidatedRouterParams(event, paramsSchema.parse);
+  const group = await findGroupBySlug(slug);
+  if (!group) {
+    throw createError({ statusCode: 404, statusMessage: 'Group not found' });
+  }
+  await requireGuardian(event, { groupId: group.id });
+
+  const db = useDrizzle();
+  const result = await db
+    .delete(tables.typingGroups)
+    .where(eq(tables.typingGroups.id, group.id))
+    .returning({ id: tables.typingGroups.id });
+
+  if (result.length === 0) {
+    throw createError({ statusCode: 404, statusMessage: 'Group not found' });
+  }
+
+  return { ok: true, deletedId: result[0]!.id };
+});

--- a/packages/layers/typing/server/api/typing/groups/[slug]/invite.post.ts
+++ b/packages/layers/typing/server/api/typing/groups/[slug]/invite.post.ts
@@ -12,9 +12,11 @@ const paramsSchema = z.object({
   slug: z.string().min(1).max(96),
 });
 
-const bodySchema = z.object({
-  email: z.string().email().optional(),
-});
+const bodySchema = z
+  .object({
+    email: z.string().email().optional(),
+  })
+  .default({});
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Summary

Two prod bugs the user hit on chris.towles.dev/typing/group:

1. **Groups silently invisible.** The page rendered "Create your family" empty-state even though the API returned 2 groups. Root cause: `useFetch`/`$fetch` in \`<script setup>\` runs during SSR but the session cookie isn't auto-forwarded to the internal fetch, so guardian-only endpoints 401, the catch path returns defaults, and the page hydrates with the empty state.
2. **No way to delete a group**, and a separately silent "Generate invite link" was throwing "Validation Error" because the FE wasn't sending a body.

Fixed both, plus several P1s from the parallel audit.

## Changes

**SSR-cookie fix:**
- \`server: false\` on \`/api/typing/groups\` and \`/api/typing/groups/:slug/learners\` so they only run client-side where the cookie is attached.
- Shared \`'typing:groups'\` key between the layout and the group page so a refresh from any mutating action propagates to the header switcher.

**\`group/learners.vue\`:**
- Replaced manual \`await load()\` + ref with \`useFetch\` keyed by \`groupSlug\` so direct URL navigation works.
- Pending state from useFetch.

**Delete group (new):**
- \`DELETE /api/typing/groups/:slug\` — guardian-only. Cascades via existing FK \`ON DELETE CASCADE\` chains (members, invites, learners, attempts, key_stats, spelling_lists).
- UI mirrors the learner delete-confirm modal — must type \`delete <group name>\` verbatim before the destructive button enables.

**Invite polish:**
- In-flight guard per group (no double-mint on rapid click).
- Full-origin URL surfaced (was just a path) with a Copy link button.
- Error path no longer swallows.
- Server: invite body schema gains \`.default({})\` so a missing body no longer throws Validation Error.

**Error surfacing:**
- Added a top-level \`role="alert"\` strip for createFamily / generateInvite / deleteGroup failures (was: silent).

## Verified end-to-end in browser on local dev

- Direct nav to \`/typing/group/learners?groupSlug=…\` loads Abby + Logan (was: "No learners yet").
- Two groups render side-by-side (was: empty state).
- Delete group on a second group removes it from the list.
- Add learner → row appears immediately.
- Delete learner → row disappears, header switcher falls back to anon if it was the active learner.
- Generate invite → \`http://localhost:3000/typing/join/<token>\` with Copy button, expiry shown.
- Join URL renders the Accept button when signed in.

## Not in this PR (deferred from audit)

- Don't-demote guard on the group-scoped PUT learners endpoint (\`useTypingProgress\` already pushes via the direct \`learners/:id/stage\` route which guards correctly).
- Atomicity in createGroup slug collision and join.post (single-user-scale not blocking).
- Lesson bests in DB (needs schema migration).
- Focus-trap / aria-labelledby on the modal (P2).
- \`MAX_STAGE\` constant duplication in client clamps.

## Test plan

- [ ] CI green
- [ ] Two groups list correctly on prod
- [ ] Delete group removes it server-side (verify DB) and clears the page
- [ ] Generate invite returns a full URL with Copy button
- [ ] Direct deep-link to \`/typing/group/learners?groupSlug=...\` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)