### PR TITLE
fix(mini-cog): use ~~ alias for shared types (fixes broken prod build)

### DIFF
--- a/packages/layers/mini-cog/app/composables/useMiniCogState.ts
+++ b/packages/layers/mini-cog/app/composables/useMiniCogState.ts
@@ -13,8 +13,8 @@ import type {
   MiniCogResultData,
   RecallScore,
   WordTriplet,
-} from '../../../../blog/shared/mini-cog-types';
-import { MINI_COG_REFER_THRESHOLD } from '../../../../blog/shared/mini-cog-types';
+} from '~~/shared/mini-cog-types';
+import { MINI_COG_REFER_THRESHOLD } from '~~/shared/mini-cog-types';
 
 const MAX_REGISTRATION_ATTEMPTS = 3;
 


### PR DESCRIPTION
## Problem

The post-merge **Deploy** of #259 failed the production Docker build:

```
[nitro] RollupError: Could not resolve "../packages/blog/shared/mini-cog-types.ts"
        from "node_modules/.cache/nuxt/.nuxt/dist/server/_nuxt/index-*.js"
```

`packages/layers/mini-cog/app/composables/useMiniCogState.ts` imported the shared types via a deep relative path (`../../../../blog/shared/mini-cog-types`) while every sibling component correctly uses the `~~/shared/...` alias. The relative path resolves under dev + vitest but the production Nitro/Rollup bundle rebases it against the build-cache dir and can't resolve it.

CI's `test` job runs vitest/lint/typecheck but **not** `nuxt build`, so #259 went green and broke `main`'s deploy on merge.

## Fix

One-line: switch the composable to `~~/shared/mini-cog-types`, matching the sibling components.

## Verification

- ✅ Full production build reproduced locally — `pnpm --filter @chris-towles/blog run build` (`build:ui-bundle` + `nuxt build` + prerender + content) → **EXIT 0**, resolution error gone.
- ✅ `pnpm test` 570 pass, lint + typecheck clean (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)