### PR TITLE
refactor(cog-playground): extract shared scorer utilities

### DIFF
--- a/packages/layers/cog-playground/server/utils/mini-cog/clock-scorer.ts
+++ b/packages/layers/cog-playground/server/utils/mini-cog/clock-scorer.ts
@@ -7,14 +7,16 @@
  * sketch, not frontier reasoning. Opus was the original default and was
  * dropped to halve cost and latency on a user-blocking call.
  *
- * Client is injectable for unit tests, same seam as the recall scorer.
+ * Thin caller of the shared `callModelForJson` helper — observability,
+ * retry, and graceful error handling all live there.
  */
 import { z } from 'zod';
 import { getAnthropicClient } from '../../../../../blog/server/utils/ai/anthropic';
 import { MODEL_SONNET } from '../../../../../blog/shared/models';
 import type { ClockScore } from '../../../../../blog/shared/cog-playground/mini-cog-types';
+import { type AnthropicLike, callModelForJson, type ParseResult } from '../shared/anthropic-call';
+import { extractJson } from '../shared/extract-json';
 import { CLOCK_SYSTEM_PROMPT } from './prompts';
-import { extractJson } from './recall-scorer';
 
 type ImageBlock = {
   type: 'image';
@@ -22,17 +24,14 @@ type ImageBlock = {
 };
 type TextBlock = { type: 'text'; text: string };
 
-export type VisionAnthropicLike = {
-  messages: {
-    create: (args: {
-      model: string;
-      max_tokens: number;
-      temperature?: number;
-      system?: string;
-      messages: Array<{ role: 'user'; content: Array<ImageBlock | TextBlock> }>;
-    }) => Promise<{ content: Array<{ type: string; text?: string }> }>;
-  };
+type VisionArgs = {
+  model: string;
+  max_tokens: number;
+  temperature?: number;
+  system?: string;
+  messages: Array<{ role: 'user'; content: Array<ImageBlock | TextBlock> }>;
 };
+export type VisionAnthropicLike = AnthropicLike<VisionArgs>;
 
 const clockSchema = z.object({
   criteria: z.object({
@@ -48,7 +47,7 @@ const clockSchema = z.object({
   explanation: z.string(),
 });
 
-export type ClockResult = { ok: true; data: ClockScore } | { ok: false; reason: string };
+export type ClockResult = ParseResult<ClockScore>;
 
 /** Strip an optional `data:image/png;base64,` prefix. */
 export function stripDataUrl(input: string): string {
@@ -98,41 +97,23 @@ export async function scoreClock(
   }
   const ai = client ?? (getAnthropicClient() as unknown as VisionAnthropicLike);
 
-  let lastReason = 'no attempts';
-  for (let attempt = 0; attempt < 2; attempt++) {
-    try {
-      const response = await ai.messages.create({
-        model: MODEL_SONNET,
-        max_tokens: 700,
-        temperature: 0,
-        system: CLOCK_SYSTEM_PROMPT,
-        messages: [
-          {
-            role: 'user',
-            content: [
-              {
-                type: 'image',
-                source: { type: 'base64', media_type: 'image/png', data },
-              },
-              {
-                type: 'text',
-                text: 'Score this clock drawing. Reply with ONLY the JSON object.',
-              },
-            ],
-          },
-        ],
-      });
-      const block = response.content[0];
-      if (!block || block.type !== 'text' || !block.text) {
-        lastReason = 'no text response';
-        continue;
-      }
-      const parsed = parseClock(block.text);
-      if (parsed.ok) return parsed;
-      lastReason = parsed.reason;
-    } catch (err) {
-      lastReason = `model request failed: ${err instanceof Error ? err.message : String(err)}`;
-    }
-  }
-  return { ok: false, reason: `failed after retries — last reason: ${lastReason}` };
+  return callModelForJson<VisionArgs, ClockScore>(
+    ai,
+    {
+      model: MODEL_SONNET,
+      max_tokens: 700,
+      temperature: 0,
+      system: CLOCK_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'image', source: { type: 'base64', media_type: 'image/png', data } },
+            { type: 'text', text: 'Score this clock drawing. Reply with ONLY the JSON object.' },
+          ],
+        },
+      ],
+    },
+    parseClock,
+  );
 }

--- a/packages/layers/cog-playground/server/utils/mini-cog/recall-scorer.test.ts
+++ b/packages/layers/cog-playground/server/utils/mini-cog/recall-scorer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { extractJson, parseRecall, scoreRecall, type RecallAnthropicLike } from './recall-scorer';
+import { parseRecall, scoreRecall, type RecallAnthropicLike } from './recall-scorer';
 
 const TARGETS = ['Banana', 'Sunrise', 'Chair'];
 
@@ -10,15 +10,6 @@ function stubClient(...replies: string[]): RecallAnthropicLike {
   }
   return { messages: { create } };
 }
-
-describe('extractJson', () => {
-  it('pulls a balanced object out of surrounding prose', () => {
-    expect(extractJson('here you go {"a":{"b":1}} thanks')).toBe('{"a":{"b":1}}');
-  });
-  it('returns null when there is no object', () => {
-    expect(extractJson('no json here')).toBeNull();
-  });
-});
 
 describe('parseRecall', () => {
   it('accepts a well-formed response and re-derives the count', () => {

--- a/packages/layers/cog-playground/server/utils/mini-cog/recall-scorer.ts
+++ b/packages/layers/cog-playground/server/utils/mini-cog/recall-scorer.ts
@@ -3,27 +3,25 @@
  * transcription against the three target words and returns a structured,
  * zod-validated breakdown.
  *
- * The Anthropic client is injectable (default: the Braintrust-wrapped
- * singleton) so unit tests can pass a stub — the same seam the typing
- * layer's lesson-generator uses.
+ * Thin caller of the shared `callModelForJson` helper — observability,
+ * retry, and graceful error handling all live there.
  */
 import { z } from 'zod';
 import { getAnthropicClient } from '../../../../../blog/server/utils/ai/anthropic';
 import { MODEL_HAIKU } from '../../../../../blog/shared/models';
 import type { RecallScore } from '../../../../../blog/shared/cog-playground/mini-cog-types';
+import { type AnthropicLike, callModelForJson, type ParseResult } from '../shared/anthropic-call';
+import { extractJson } from '../shared/extract-json';
 import { RECALL_SYSTEM_PROMPT } from './prompts';
 
-export type RecallAnthropicLike = {
-  messages: {
-    create: (args: {
-      model: string;
-      max_tokens: number;
-      temperature?: number;
-      system?: string;
-      messages: Array<{ role: 'user'; content: string }>;
-    }) => Promise<{ content: Array<{ type: string; text?: string }> }>;
-  };
+type RecallArgs = {
+  model: string;
+  max_tokens: number;
+  temperature?: number;
+  system?: string;
+  messages: Array<{ role: 'user'; content: string }>;
 };
+export type RecallAnthropicLike = AnthropicLike<RecallArgs>;
 
 const recallSchema = z.object({
   scores: z
@@ -39,23 +37,7 @@ const recallSchema = z.object({
   totalRecalled: z.number().int().min(0).max(3),
 });
 
-export type RecallResult = { ok: true; data: RecallScore } | { ok: false; reason: string };
-
-/** Pull the first balanced JSON object out of a model reply. */
-export function extractJson(text: string): string | null {
-  const start = text.indexOf('{');
-  if (start === -1) return null;
-  let depth = 0;
-  for (let i = start; i < text.length; i++) {
-    const ch = text[i];
-    if (ch === '{') depth++;
-    else if (ch === '}') {
-      depth--;
-      if (depth === 0) return text.slice(start, i + 1);
-    }
-  }
-  return null;
-}
+export type RecallResult = ParseResult<RecallScore>;
 
 export function parseRecall(raw: string, targetWords: string[]): RecallResult {
   const json = extractJson(raw);
@@ -96,27 +78,15 @@ export async function scoreRecall(
     'Score each target word and reply with ONLY the JSON object.',
   ].join('\n');
 
-  let lastReason = 'no attempts';
-  for (let attempt = 0; attempt < 2; attempt++) {
-    try {
-      const response = await ai.messages.create({
-        model: MODEL_HAIKU,
-        max_tokens: 500,
-        temperature: 0,
-        system: RECALL_SYSTEM_PROMPT,
-        messages: [{ role: 'user', content: userPrompt }],
-      });
-      const block = response.content[0];
-      if (!block || block.type !== 'text' || !block.text) {
-        lastReason = 'no text response';
-        continue;
-      }
-      const parsed = parseRecall(block.text, input.targetWords);
-      if (parsed.ok) return parsed;
-      lastReason = parsed.reason;
-    } catch (err) {
-      lastReason = `model request failed: ${err instanceof Error ? err.message : String(err)}`;
-    }
-  }
-  return { ok: false, reason: `failed after retries — last reason: ${lastReason}` };
+  return callModelForJson<RecallArgs, RecallScore>(
+    ai,
+    {
+      model: MODEL_HAIKU,
+      max_tokens: 500,
+      temperature: 0,
+      system: RECALL_SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: userPrompt }],
+    },
+    (text) => parseRecall(text, input.targetWords),
+  );
 }

--- a/packages/layers/cog-playground/server/utils/shared/anthropic-call.ts
+++ b/packages/layers/cog-playground/server/utils/shared/anthropic-call.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared "call Claude for a JSON answer" helper for the cog-playground
+ * scorers.
+ *
+ * Three responsibilities collapsed into one place so each scorer is a
+ * thin "request payload + parser" pair:
+ *
+ *   1. Wrap the SDK call in `withAnthropicSpan` per the project's
+ *      observability convention (CLAUDE.md "Wrapper rule" — never call
+ *      `client.messages.create(...)` directly at a site that should be
+ *      traced). The Braintrust singleton inside `getAnthropicClient()`
+ *      is a parallel observability layer and unaffected.
+ *   2. Catch any SDK throw (spend cap, transient 5xx, network) and
+ *      convert it to a graceful `{ ok: false, reason }` instead of an
+ *      unhandled 500 with a stack-trace dump.
+ *   3. Bounded retries: if the model returns an empty/non-text block or
+ *      the caller's `parse` rejects the body, try again (default 2
+ *      attempts).
+ *
+ * The Anthropic client is injectable so unit tests can pass a stub —
+ * same seam as the typing layer's `lesson-generator`.
+ */
+import { withAnthropicSpan } from '../../../../../blog/server/utils/observability/anthropic';
+
+export type ParseResult<T> = { ok: true; data: T } | { ok: false; reason: string };
+export type ParseFn<T> = (text: string) => ParseResult<T>;
+
+/**
+ * Minimal shape the helper needs from a Claude client. Lets test stubs
+ * return only `{ content: [...] }` without satisfying the full SDK
+ * response type — same approach the scorer-specific `*AnthropicLike`
+ * types used before this extraction.
+ */
+export type AnthropicLike<TArgs extends { model: string }> = {
+  messages: {
+    create: (args: TArgs) => Promise<{ content: Array<{ type: string; text?: string }> }>;
+  };
+};
+
+export type CallModelForJsonOptions = {
+  /** Number of attempts (default: 2). One failed parse uses one attempt. */
+  attempts?: number;
+  /** Span `operation` label (default: 'chat'), per OTel GenAI semconv. */
+  operation?: string;
+};
+
+/**
+ * Call the model, extract a single text block, hand it to `parse`. On
+ * any thrown SDK error, empty response, or failed parse, retry up to
+ * `opts.attempts` times. Returns the parsed value on success or a
+ * `{ ok: false, reason }` describing the last failure.
+ *
+ * The span ends after each attempt regardless of success — re-attempts
+ * start a fresh span so each call site shows up cleanly in traces.
+ */
+export async function callModelForJson<TArgs extends { model: string }, T>(
+  client: AnthropicLike<TArgs>,
+  args: TArgs,
+  parse: ParseFn<T>,
+  opts: CallModelForJsonOptions = {},
+): Promise<ParseResult<T>> {
+  const attempts = opts.attempts ?? 2;
+  const operation = opts.operation ?? 'chat';
+  let lastReason = 'no attempts';
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const response = await withAnthropicSpan(operation, args.model, () =>
+        client.messages.create(args),
+      );
+      const block = response.content[0];
+      if (!block || block.type !== 'text' || !block.text) {
+        lastReason = 'no text response';
+        continue;
+      }
+      const parsed = parse(block.text);
+      if (parsed.ok) return parsed;
+      lastReason = parsed.reason;
+    } catch (err) {
+      lastReason = `model request failed: ${err instanceof Error ? err.message : String(err)}`;
+    }
+  }
+  return { ok: false, reason: `failed after retries — last reason: ${lastReason}` };
+}

--- a/packages/layers/cog-playground/server/utils/shared/extract-json.test.ts
+++ b/packages/layers/cog-playground/server/utils/shared/extract-json.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { extractJson } from './extract-json';
+
+describe('extractJson', () => {
+  it('pulls a balanced object out of surrounding prose', () => {
+    expect(extractJson('here you go {"a":{"b":1}} thanks')).toBe('{"a":{"b":1}}');
+  });
+  it('returns null when there is no object', () => {
+    expect(extractJson('no json here')).toBeNull();
+  });
+});

--- a/packages/layers/cog-playground/server/utils/shared/extract-json.ts
+++ b/packages/layers/cog-playground/server/utils/shared/extract-json.ts
@@ -1,0 +1,22 @@
+/**
+ * Pull the first balanced JSON object out of a model reply. Tolerates
+ * leading/trailing prose. Returns the raw JSON substring, or null when
+ * no balanced object can be found.
+ *
+ * Shared across the cog-playground scorers (recall, clock, fluency,
+ * verbal) so each can be a thin caller of the model + parser pair.
+ */
+export function extractJson(text: string): string | null {
+  const start = text.indexOf('{');
+  if (start === -1) return null;
+  let depth = 0;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return text.slice(start, i + 1);
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Phase 2 / 5 of the cog-playground plan

Extracts the two duplicated pieces from the recall + clock scorers into a `shared/` subdirectory, and adopts the project's documented Anthropic observability wrapper from day one — so phases 3 and 4 (composed + Mini-ACE) inherit it instead of extending the gap.

### Changes
- **`server/utils/shared/extract-json.ts`** — the balanced-brace JSON extractor that was living in `recall-scorer.ts`. Both scorers now import from here; `clock-scorer` no longer reaches into `recall-scorer`. Its tests move alongside it (`extract-json.test.ts`).
- **`server/utils/shared/anthropic-call.ts`** — `callModelForJson<TArgs, T>(client, args, parse, opts?)`. One helper that owns:
  1. Wrapping `client.messages.create` in `withAnthropicSpan` per CLAUDE.md's "Wrapper rule" — every Anthropic SDK call site must go through it for traces. The cog-playground scorers were the existing gap; this closes it for them.
  2. Catching SDK throws into a graceful `{ ok: false, reason }` (so a spend cap or network blip doesn't leak as an unhandled 500 with a stack trace).
  3. The bounded retry loop.
  Generic over the args type so the text-only recall payload and the image+text clock payload both pass through unchanged.
- **`recall-scorer.ts` and `clock-scorer.ts`** become thin "build payload, supply parser" call sites. Their `RecallAnthropicLike` / `VisionAnthropicLike` types are now aliases of the shared `AnthropicLike<TArgs>` so test stubs are unchanged.

Net: **−51 lines** of duplicated retry/observability code, **+105 lines** of shared infrastructure tests would otherwise have to re-duplicate again in phases 3+4.

### Out of scope (separate follow-up)
Adopting `withAnthropicSpan` in the existing typing layer's `lesson-generator.ts` — also a known gap but a separate cross-layer concern.

### Verification
- ✅ `pnpm lint` clean
- ✅ `pnpm typecheck` clean
- ✅ `pnpm test` — **570 passed | 11 skipped** (unchanged; extractJson tests moved file but same count). Test files went 57 → 58 (new `extract-json.test.ts`).
- ✅ Full production build (`pnpm --filter @chris-towles/blog run build`, `NODE_OPTIONS=--max-old-space-size=8192`) — EXIT 0. Both Client (18s) and Server (9s) bundles built cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)