### PR TITLE
fix(db): repair drizzle meta snapshots after hand-written cutover migrations

### DIFF
--- a/packages/blog/server/database/migrations/meta/0011_snapshot.json
+++ b/packages/blog/server/database/migrations/meta/0011_snapshot.json
@@ -633,8 +633,8 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.achievements": {
-      "name": "achievements",
+    "public.typing_attempts": {
+      "name": "typing_attempts",
       "schema": "",
       "columns": {
         "id": {
@@ -643,38 +643,106 @@
           "primaryKey": true,
           "notNull": true
         },
-        "childId": {
-          "name": "childId",
+        "learnerId": {
+          "name": "learnerId",
           "type": "integer",
           "primaryKey": false,
           "notNull": true
         },
-        "type": {
-          "name": "type",
-          "type": "varchar(50)",
+        "lessonId": {
+          "name": "lessonId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gameSlug": {
+          "name": "gameSlug",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wpm": {
+          "name": "wpm",
+          "type": "real",
           "primaryKey": false,
           "notNull": true
         },
-        "earnedAt": {
-          "name": "earnedAt",
+        "netWpm": {
+          "name": "netWpm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "accuracy": {
+          "name": "accuracy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "errorsByKey": {
+          "name": "errorsByKey",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "completedAt": {
+          "name": "completedAt",
           "type": "timestamp",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
-        },
-        "meta": {
-          "name": "meta",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
         }
       },
       "indexes": {
-        "achievements_child_id_idx": {
-          "name": "achievements_child_id_idx",
+        "typing_attempts_learner_id_completed_at_idx": {
+          "name": "typing_attempts_learner_id_completed_at_idx",
           "columns": [
             {
-              "expression": "childId",
+              "expression": "learnerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "typing_attempts_lesson_id_idx": {
+          "name": "typing_attempts_lesson_id_idx",
+          "columns": [
+            {
+              "expression": "lessonId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "typing_attempts_game_slug_idx": {
+          "name": "typing_attempts_game_slug_idx",
+          "columns": [
+            {
+              "expression": "gameSlug",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -687,13 +755,22 @@
         }
       },
       "foreignKeys": {
-        "achievements_childId_child_profiles_id_fk": {
-          "name": "achievements_childId_child_profiles_id_fk",
-          "tableFrom": "achievements",
-          "tableTo": "child_profiles",
-          "columnsFrom": ["childId"],
+        "typing_attempts_learnerId_typing_learners_id_fk": {
+          "name": "typing_attempts_learnerId_typing_learners_id_fk",
+          "tableFrom": "typing_attempts",
+          "tableTo": "typing_learners",
+          "columnsFrom": ["learnerId"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "typing_attempts_lessonId_typing_lessons_id_fk": {
+          "name": "typing_attempts_lessonId_typing_lessons_id_fk",
+          "tableFrom": "typing_attempts",
+          "tableTo": "typing_lessons",
+          "columnsFrom": ["lessonId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
           "onUpdate": "no action"
         }
       },
@@ -703,8 +780,8 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.child_phonics_progress": {
-      "name": "child_phonics_progress",
+    "public.typing_group_invites": {
+      "name": "typing_group_invites",
       "schema": "",
       "columns": {
         "id": {
@@ -713,38 +790,71 @@
           "primaryKey": true,
           "notNull": true
         },
-        "childId": {
-          "name": "childId",
+        "groupId": {
+          "name": "groupId",
           "type": "integer",
           "primaryKey": false,
           "notNull": true
         },
-        "phonicsUnitId": {
-          "name": "phonicsUnitId",
-          "type": "integer",
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
           "primaryKey": false,
           "notNull": true
         },
-        "status": {
-          "name": "status",
-          "type": "varchar(20)",
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
           "primaryKey": false,
-          "notNull": true,
-          "default": "'locked'"
+          "notNull": false
         },
-        "masteredAt": {
-          "name": "masteredAt",
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptedBy": {
+          "name": "acceptedBy",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
           "type": "timestamp",
           "primaryKey": false,
           "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
         }
       },
       "indexes": {
-        "child_phonics_progress_child_id_idx": {
-          "name": "child_phonics_progress_child_id_idx",
+        "typing_group_invites_token_idx": {
+          "name": "typing_group_invites_token_idx",
           "columns": [
             {
-              "expression": "childId",
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "typing_group_invites_group_id_idx": {
+          "name": "typing_group_invites_group_id_idx",
+          "columns": [
+            {
+              "expression": "groupId",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -757,20 +867,20 @@
         }
       },
       "foreignKeys": {
-        "child_phonics_progress_childId_child_profiles_id_fk": {
-          "name": "child_phonics_progress_childId_child_profiles_id_fk",
-          "tableFrom": "child_phonics_progress",
-          "tableTo": "child_profiles",
-          "columnsFrom": ["childId"],
+        "typing_group_invites_groupId_typing_groups_id_fk": {
+          "name": "typing_group_invites_groupId_typing_groups_id_fk",
+          "tableFrom": "typing_group_invites",
+          "tableTo": "typing_groups",
+          "columnsFrom": ["groupId"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
-        "child_phonics_progress_phonicsUnitId_phonics_units_id_fk": {
-          "name": "child_phonics_progress_phonicsUnitId_phonics_units_id_fk",
-          "tableFrom": "child_phonics_progress",
-          "tableTo": "phonics_units",
-          "columnsFrom": ["phonicsUnitId"],
+        "typing_group_invites_acceptedBy_users_id_fk": {
+          "name": "typing_group_invites_acceptedBy_users_id_fk",
+          "tableFrom": "typing_group_invites",
+          "tableTo": "users",
+          "columnsFrom": ["acceptedBy"],
           "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
@@ -782,14 +892,14 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.child_profiles": {
-      "name": "child_profiles",
+    "public.typing_group_members": {
+      "name": "typing_group_members",
       "schema": "",
       "columns": {
-        "id": {
-          "name": "id",
-          "type": "serial",
-          "primaryKey": true,
+        "groupId": {
+          "name": "groupId",
+          "type": "integer",
+          "primaryKey": false,
           "notNull": true
         },
         "userId": {
@@ -798,9 +908,240 @@
           "primaryKey": false,
           "notNull": true
         },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'guardian'"
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joinedAt": {
+          "name": "joinedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "typing_group_members_user_id_idx": {
+          "name": "typing_group_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "typing_group_members_groupId_typing_groups_id_fk": {
+          "name": "typing_group_members_groupId_typing_groups_id_fk",
+          "tableFrom": "typing_group_members",
+          "tableTo": "typing_groups",
+          "columnsFrom": ["groupId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "typing_group_members_userId_users_id_fk": {
+          "name": "typing_group_members_userId_users_id_fk",
+          "tableFrom": "typing_group_members",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "typing_group_members_invitedBy_users_id_fk": {
+          "name": "typing_group_members_invitedBy_users_id_fk",
+          "tableFrom": "typing_group_members",
+          "tableTo": "users",
+          "columnsFrom": ["invitedBy"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "typing_group_members_groupId_userId_pk": {
+          "name": "typing_group_members_groupId_userId_pk",
+          "columns": ["groupId", "userId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.typing_groups": {
+      "name": "typing_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
         "name": {
           "name": "name",
-          "type": "varchar(100)",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'family'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.typing_key_stats": {
+      "name": "typing_key_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "learnerId": {
+          "name": "learnerId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "avgMs": {
+          "name": "avgMs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "typing_key_stats_learner_id_key_idx": {
+          "name": "typing_key_stats_learner_id_key_idx",
+          "columns": [
+            {
+              "expression": "learnerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "typing_key_stats_learnerId_typing_learners_id_fk": {
+          "name": "typing_key_stats_learnerId_typing_learners_id_fk",
+          "tableFrom": "typing_key_stats",
+          "tableTo": "typing_learners",
+          "columnsFrom": ["learnerId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.typing_learners": {
+      "name": "typing_learners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "groupId": {
+          "name": "groupId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "varchar(80)",
           "primaryKey": false,
           "notNull": true
         },
@@ -814,21 +1155,21 @@
           "name": "birthYear",
           "type": "integer",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
-        "currentPhase": {
-          "name": "currentPhase",
+        "currentStage": {
+          "name": "currentStage",
           "type": "integer",
           "primaryKey": false,
           "notNull": true,
           "default": 1
         },
-        "interests": {
-          "name": "interests",
-          "type": "text[]",
+        "preferredVoice": {
+          "name": "preferredVoice",
+          "type": "varchar(64)",
           "primaryKey": false,
           "notNull": true,
-          "default": "'{}'"
+          "default": "'chirp3-en-us-Aoede'"
         },
         "createdAt": {
           "name": "createdAt",
@@ -846,11 +1187,11 @@
         }
       },
       "indexes": {
-        "child_profiles_user_id_idx": {
-          "name": "child_profiles_user_id_idx",
+        "typing_learners_group_id_idx": {
+          "name": "typing_learners_group_id_idx",
           "columns": [
             {
-              "expression": "userId",
+              "expression": "groupId",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -863,11 +1204,11 @@
         }
       },
       "foreignKeys": {
-        "child_profiles_userId_users_id_fk": {
-          "name": "child_profiles_userId_users_id_fk",
-          "tableFrom": "child_profiles",
-          "tableTo": "users",
-          "columnsFrom": ["userId"],
+        "typing_learners_groupId_typing_groups_id_fk": {
+          "name": "typing_learners_groupId_typing_groups_id_fk",
+          "tableFrom": "typing_learners",
+          "tableTo": "typing_groups",
+          "columnsFrom": ["groupId"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -879,8 +1220,8 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.phonics_units": {
-      "name": "phonics_units",
+    "public.typing_lessons": {
+      "name": "typing_lessons",
       "schema": "",
       "columns": {
         "id": {
@@ -889,390 +1230,68 @@
           "primaryKey": true,
           "notNull": true
         },
-        "phase": {
-          "name": "phase",
+        "slug": {
+          "name": "slug",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
           "type": "integer",
           "primaryKey": false,
           "notNull": true
         },
-        "orderIndex": {
-          "name": "orderIndex",
-          "type": "integer",
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
           "primaryKey": false,
           "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(100)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "patterns": {
-          "name": "patterns",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'"
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "''"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.reading_sessions": {
-      "name": "reading_sessions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "childId": {
-          "name": "childId",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "storyId": {
-          "name": "storyId",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "mode": {
-          "name": "mode",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "wcpm": {
-          "name": "wcpm",
-          "type": "real",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "accuracy": {
-          "name": "accuracy",
-          "type": "real",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "duration": {
-          "name": "duration",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "miscues": {
-          "name": "miscues",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "recordingUrl": {
-          "name": "recordingUrl",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "completedAt": {
-          "name": "completedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "reading_sessions_child_id_completed_idx": {
-          "name": "reading_sessions_child_id_completed_idx",
-          "columns": [
-            {
-              "expression": "childId",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "completedAt",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "reading_sessions_childId_child_profiles_id_fk": {
-          "name": "reading_sessions_childId_child_profiles_id_fk",
-          "tableFrom": "reading_sessions",
-          "tableTo": "child_profiles",
-          "columnsFrom": ["childId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "reading_sessions_storyId_stories_id_fk": {
-          "name": "reading_sessions_storyId_stories_id_fk",
-          "tableFrom": "reading_sessions",
-          "tableTo": "stories",
-          "columnsFrom": ["storyId"],
-          "columnsTo": ["id"],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.srs_cards": {
-      "name": "srs_cards",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "childId": {
-          "name": "childId",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "cardType": {
-          "name": "cardType",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "front": {
-          "name": "front",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "back": {
-          "name": "back",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "audioUrl": {
-          "name": "audioUrl",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "state": {
-          "name": "state",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "difficulty": {
-          "name": "difficulty",
-          "type": "real",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "stability": {
-          "name": "stability",
-          "type": "real",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "due": {
-          "name": "due",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "lastReview": {
-          "name": "lastReview",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "reps": {
-          "name": "reps",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "lapses": {
-          "name": "lapses",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "relatedPhonicsUnitId": {
-          "name": "relatedPhonicsUnitId",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "srs_cards_child_id_due_idx": {
-          "name": "srs_cards_child_id_due_idx",
-          "columns": [
-            {
-              "expression": "childId",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "due",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "srs_cards_childId_child_profiles_id_fk": {
-          "name": "srs_cards_childId_child_profiles_id_fk",
-          "tableFrom": "srs_cards",
-          "tableTo": "child_profiles",
-          "columnsFrom": ["childId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "srs_cards_relatedPhonicsUnitId_phonics_units_id_fk": {
-          "name": "srs_cards_relatedPhonicsUnitId_phonics_units_id_fk",
-          "tableFrom": "srs_cards",
-          "tableTo": "phonics_units",
-          "columnsFrom": ["relatedPhonicsUnitId"],
-          "columnsTo": ["id"],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.stories": {
-      "name": "stories",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "childId": {
-          "name": "childId",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
         },
         "title": {
           "name": "title",
-          "type": "varchar(200)",
+          "type": "varchar(160)",
           "primaryKey": false,
           "notNull": true
         },
-        "content": {
-          "name": "content",
-          "type": "jsonb",
+        "text": {
+          "name": "text",
+          "type": "text",
           "primaryKey": false,
           "notNull": true
         },
-        "theme": {
-          "name": "theme",
-          "type": "varchar(100)",
+        "targetWpm": {
+          "name": "targetWpm",
+          "type": "integer",
           "primaryKey": false,
           "notNull": true,
-          "default": "''"
+          "default": 10
         },
-        "targetPatterns": {
-          "name": "targetPatterns",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'"
-        },
-        "targetWords": {
-          "name": "targetWords",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'"
-        },
-        "decodabilityScore": {
-          "name": "decodabilityScore",
+        "targetAccuracy": {
+          "name": "targetAccuracy",
           "type": "real",
           "primaryKey": false,
           "notNull": true,
-          "default": 0
+          "default": 0.95
         },
-        "fleschKincaid": {
-          "name": "fleschKincaid",
-          "type": "real",
+        "topic": {
+          "name": "topic",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spellingListId": {
+          "name": "spellingListId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generatedBy": {
+          "name": "generatedBy",
+          "type": "varchar(16)",
           "primaryKey": false,
           "notNull": true,
-          "default": 0
-        },
-        "illustrationUrls": {
-          "name": "illustrationUrls",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'"
-        },
-        "aiGenerated": {
-          "name": "aiGenerated",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "favorited": {
-          "name": "favorited",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
+          "default": "'system'"
         },
         "createdAt": {
           "name": "createdAt",
@@ -1283,11 +1302,41 @@
         }
       },
       "indexes": {
-        "stories_child_id_idx": {
-          "name": "stories_child_id_idx",
+        "typing_lessons_slug_idx": {
+          "name": "typing_lessons_slug_idx",
           "columns": [
             {
-              "expression": "childId",
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "typing_lessons_stage_idx": {
+          "name": "typing_lessons_stage_idx",
+          "columns": [
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "typing_lessons_spelling_list_id_idx": {
+          "name": "typing_lessons_spelling_list_id_idx",
+          "columns": [
+            {
+              "expression": "spellingListId",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -1299,14 +1348,199 @@
           "with": {}
         }
       },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.typing_spelling_lists": {
+      "name": "typing_spelling_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "learnerId": {
+          "name": "learnerId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekOf": {
+          "name": "weekOf",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "words": {
+          "name": "words",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'type'"
+        },
+        "sourceImageUrl": {
+          "name": "sourceImageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "typing_spelling_lists_learner_id_week_of_idx": {
+          "name": "typing_spelling_lists_learner_id_week_of_idx",
+          "columns": [
+            {
+              "expression": "learnerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weekOf",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {
-        "stories_childId_child_profiles_id_fk": {
-          "name": "stories_childId_child_profiles_id_fk",
-          "tableFrom": "stories",
-          "tableTo": "child_profiles",
-          "columnsFrom": ["childId"],
+        "typing_spelling_lists_learnerId_typing_learners_id_fk": {
+          "name": "typing_spelling_lists_learnerId_typing_learners_id_fk",
+          "tableFrom": "typing_spelling_lists",
+          "tableTo": "typing_learners",
+          "columnsFrom": ["learnerId"],
           "columnsTo": ["id"],
-          "onDelete": "set null",
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "typing_spelling_lists_createdBy_users_id_fk": {
+          "name": "typing_spelling_lists_createdBy_users_id_fk",
+          "tableFrom": "typing_spelling_lists",
+          "tableTo": "users",
+          "columnsFrom": ["createdBy"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.typing_spelling_progress": {
+      "name": "typing_spelling_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "spellingListId": {
+          "name": "spellingListId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "word": {
+          "name": "word",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consecutiveCorrect": {
+          "name": "consecutiveCorrect",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "mastered": {
+          "name": "mastered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "masteredAt": {
+          "name": "masteredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "typing_spelling_progress_list_word_idx": {
+          "name": "typing_spelling_progress_list_word_idx",
+          "columns": [
+            {
+              "expression": "spellingListId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "word",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "typing_spelling_progress_spellingListId_typing_spelling_lists_id_fk": {
+          "name": "typing_spelling_progress_spellingListId_typing_spelling_lists_id_fk",
+          "tableFrom": "typing_spelling_progress",
+          "tableTo": "typing_spelling_lists",
+          "columnsFrom": ["spellingListId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
           "onUpdate": "no action"
         }
       },
@@ -1569,7 +1803,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'claude-sonnet-4-20250514'"
+          "default": "'claude-haiku-4-5'"
         },
         "temperature": {
           "name": "temperature",

--- a/packages/blog/server/database/migrations/meta/0012_snapshot.json
+++ b/packages/blog/server/database/migrations/meta/0012_snapshot.json
@@ -633,8 +633,8 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.achievements": {
-      "name": "achievements",
+    "public.typing_attempts": {
+      "name": "typing_attempts",
       "schema": "",
       "columns": {
         "id": {
@@ -643,38 +643,106 @@
           "primaryKey": true,
           "notNull": true
         },
-        "childId": {
-          "name": "childId",
+        "learnerId": {
+          "name": "learnerId",
           "type": "integer",
           "primaryKey": false,
           "notNull": true
         },
-        "type": {
-          "name": "type",
-          "type": "varchar(50)",
+        "lessonId": {
+          "name": "lessonId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gameSlug": {
+          "name": "gameSlug",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wpm": {
+          "name": "wpm",
+          "type": "real",
           "primaryKey": false,
           "notNull": true
         },
-        "earnedAt": {
-          "name": "earnedAt",
+        "netWpm": {
+          "name": "netWpm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "accuracy": {
+          "name": "accuracy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "errorsByKey": {
+          "name": "errorsByKey",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "completedAt": {
+          "name": "completedAt",
           "type": "timestamp",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
-        },
-        "meta": {
-          "name": "meta",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
         }
       },
       "indexes": {
-        "achievements_child_id_idx": {
-          "name": "achievements_child_id_idx",
+        "typing_attempts_learner_id_completed_at_idx": {
+          "name": "typing_attempts_learner_id_completed_at_idx",
           "columns": [
             {
-              "expression": "childId",
+              "expression": "learnerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "typing_attempts_lesson_id_idx": {
+          "name": "typing_attempts_lesson_id_idx",
+          "columns": [
+            {
+              "expression": "lessonId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "typing_attempts_game_slug_idx": {
+          "name": "typing_attempts_game_slug_idx",
+          "columns": [
+            {
+              "expression": "gameSlug",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -687,13 +755,22 @@
         }
       },
       "foreignKeys": {
-        "achievements_childId_child_profiles_id_fk": {
-          "name": "achievements_childId_child_profiles_id_fk",
-          "tableFrom": "achievements",
-          "tableTo": "child_profiles",
-          "columnsFrom": ["childId"],
+        "typing_attempts_learnerId_typing_learners_id_fk": {
+          "name": "typing_attempts_learnerId_typing_learners_id_fk",
+          "tableFrom": "typing_attempts",
+          "tableTo": "typing_learners",
+          "columnsFrom": ["learnerId"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "typing_attempts_lessonId_typing_lessons_id_fk": {
+          "name": "typing_attempts_lessonId_typing_lessons_id_fk",
+          "tableFrom": "typing_attempts",
+          "tableTo": "typing_lessons",
+          "columnsFrom": ["lessonId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
           "onUpdate": "no action"
         }
       },
@@ -703,8 +780,8 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.child_phonics_progress": {
-      "name": "child_phonics_progress",
+    "public.typing_group_invites": {
+      "name": "typing_group_invites",
       "schema": "",
       "columns": {
         "id": {
@@ -713,38 +790,71 @@
           "primaryKey": true,
           "notNull": true
         },
-        "childId": {
-          "name": "childId",
+        "groupId": {
+          "name": "groupId",
           "type": "integer",
           "primaryKey": false,
           "notNull": true
         },
-        "phonicsUnitId": {
-          "name": "phonicsUnitId",
-          "type": "integer",
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
           "primaryKey": false,
           "notNull": true
         },
-        "status": {
-          "name": "status",
-          "type": "varchar(20)",
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
           "primaryKey": false,
-          "notNull": true,
-          "default": "'locked'"
+          "notNull": false
         },
-        "masteredAt": {
-          "name": "masteredAt",
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptedBy": {
+          "name": "acceptedBy",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
           "type": "timestamp",
           "primaryKey": false,
           "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
         }
       },
       "indexes": {
-        "child_phonics_progress_child_id_idx": {
-          "name": "child_phonics_progress_child_id_idx",
+        "typing_group_invites_token_idx": {
+          "name": "typing_group_invites_token_idx",
           "columns": [
             {
-              "expression": "childId",
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "typing_group_invites_group_id_idx": {
+          "name": "typing_group_invites_group_id_idx",
+          "columns": [
+            {
+              "expression": "groupId",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -757,20 +867,20 @@
         }
       },
       "foreignKeys": {
-        "child_phonics_progress_childId_child_profiles_id_fk": {
-          "name": "child_phonics_progress_childId_child_profiles_id_fk",
-          "tableFrom": "child_phonics_progress",
-          "tableTo": "child_profiles",
-          "columnsFrom": ["childId"],
+        "typing_group_invites_groupId_typing_groups_id_fk": {
+          "name": "typing_group_invites_groupId_typing_groups_id_fk",
+          "tableFrom": "typing_group_invites",
+          "tableTo": "typing_groups",
+          "columnsFrom": ["groupId"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
-        "child_phonics_progress_phonicsUnitId_phonics_units_id_fk": {
-          "name": "child_phonics_progress_phonicsUnitId_phonics_units_id_fk",
-          "tableFrom": "child_phonics_progress",
-          "tableTo": "phonics_units",
-          "columnsFrom": ["phonicsUnitId"],
+        "typing_group_invites_acceptedBy_users_id_fk": {
+          "name": "typing_group_invites_acceptedBy_users_id_fk",
+          "tableFrom": "typing_group_invites",
+          "tableTo": "users",
+          "columnsFrom": ["acceptedBy"],
           "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
@@ -782,14 +892,14 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.child_profiles": {
-      "name": "child_profiles",
+    "public.typing_group_members": {
+      "name": "typing_group_members",
       "schema": "",
       "columns": {
-        "id": {
-          "name": "id",
-          "type": "serial",
-          "primaryKey": true,
+        "groupId": {
+          "name": "groupId",
+          "type": "integer",
+          "primaryKey": false,
           "notNull": true
         },
         "userId": {
@@ -798,9 +908,252 @@
           "primaryKey": false,
           "notNull": true
         },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'guardian'"
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joinedAt": {
+          "name": "joinedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "typing_group_members_user_id_idx": {
+          "name": "typing_group_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "typing_group_members_groupId_typing_groups_id_fk": {
+          "name": "typing_group_members_groupId_typing_groups_id_fk",
+          "tableFrom": "typing_group_members",
+          "tableTo": "typing_groups",
+          "columnsFrom": ["groupId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "typing_group_members_userId_users_id_fk": {
+          "name": "typing_group_members_userId_users_id_fk",
+          "tableFrom": "typing_group_members",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "typing_group_members_invitedBy_users_id_fk": {
+          "name": "typing_group_members_invitedBy_users_id_fk",
+          "tableFrom": "typing_group_members",
+          "tableTo": "users",
+          "columnsFrom": ["invitedBy"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "typing_group_members_groupId_userId_pk": {
+          "name": "typing_group_members_groupId_userId_pk",
+          "columns": ["groupId", "userId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.typing_groups": {
+      "name": "typing_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
         "name": {
           "name": "name",
-          "type": "varchar(100)",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'family'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "typing_groups_slug_unique": {
+          "name": "typing_groups_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.typing_key_stats": {
+      "name": "typing_key_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "learnerId": {
+          "name": "learnerId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "avgMs": {
+          "name": "avgMs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "typing_key_stats_learner_id_key_idx": {
+          "name": "typing_key_stats_learner_id_key_idx",
+          "columns": [
+            {
+              "expression": "learnerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "typing_key_stats_learnerId_typing_learners_id_fk": {
+          "name": "typing_key_stats_learnerId_typing_learners_id_fk",
+          "tableFrom": "typing_key_stats",
+          "tableTo": "typing_learners",
+          "columnsFrom": ["learnerId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.typing_learners": {
+      "name": "typing_learners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "groupId": {
+          "name": "groupId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "varchar(80)",
           "primaryKey": false,
           "notNull": true
         },
@@ -814,21 +1167,21 @@
           "name": "birthYear",
           "type": "integer",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
-        "currentPhase": {
-          "name": "currentPhase",
+        "currentStage": {
+          "name": "currentStage",
           "type": "integer",
           "primaryKey": false,
           "notNull": true,
           "default": 1
         },
-        "interests": {
-          "name": "interests",
-          "type": "text[]",
+        "preferredVoice": {
+          "name": "preferredVoice",
+          "type": "varchar(64)",
           "primaryKey": false,
           "notNull": true,
-          "default": "'{}'"
+          "default": "'chirp3-en-us-Aoede'"
         },
         "createdAt": {
           "name": "createdAt",
@@ -846,11 +1199,11 @@
         }
       },
       "indexes": {
-        "child_profiles_user_id_idx": {
-          "name": "child_profiles_user_id_idx",
+        "typing_learners_group_id_idx": {
+          "name": "typing_learners_group_id_idx",
           "columns": [
             {
-              "expression": "userId",
+              "expression": "groupId",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -863,11 +1216,11 @@
         }
       },
       "foreignKeys": {
-        "child_profiles_userId_users_id_fk": {
-          "name": "child_profiles_userId_users_id_fk",
-          "tableFrom": "child_profiles",
-          "tableTo": "users",
-          "columnsFrom": ["userId"],
+        "typing_learners_groupId_typing_groups_id_fk": {
+          "name": "typing_learners_groupId_typing_groups_id_fk",
+          "tableFrom": "typing_learners",
+          "tableTo": "typing_groups",
+          "columnsFrom": ["groupId"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -879,8 +1232,8 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.phonics_units": {
-      "name": "phonics_units",
+    "public.typing_lessons": {
+      "name": "typing_lessons",
       "schema": "",
       "columns": {
         "id": {
@@ -889,390 +1242,68 @@
           "primaryKey": true,
           "notNull": true
         },
-        "phase": {
-          "name": "phase",
+        "slug": {
+          "name": "slug",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
           "type": "integer",
           "primaryKey": false,
           "notNull": true
         },
-        "orderIndex": {
-          "name": "orderIndex",
-          "type": "integer",
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
           "primaryKey": false,
           "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(100)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "patterns": {
-          "name": "patterns",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'"
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "''"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.reading_sessions": {
-      "name": "reading_sessions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "childId": {
-          "name": "childId",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "storyId": {
-          "name": "storyId",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "mode": {
-          "name": "mode",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "wcpm": {
-          "name": "wcpm",
-          "type": "real",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "accuracy": {
-          "name": "accuracy",
-          "type": "real",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "duration": {
-          "name": "duration",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "miscues": {
-          "name": "miscues",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "recordingUrl": {
-          "name": "recordingUrl",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "completedAt": {
-          "name": "completedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "reading_sessions_child_id_completed_idx": {
-          "name": "reading_sessions_child_id_completed_idx",
-          "columns": [
-            {
-              "expression": "childId",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "completedAt",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "reading_sessions_childId_child_profiles_id_fk": {
-          "name": "reading_sessions_childId_child_profiles_id_fk",
-          "tableFrom": "reading_sessions",
-          "tableTo": "child_profiles",
-          "columnsFrom": ["childId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "reading_sessions_storyId_stories_id_fk": {
-          "name": "reading_sessions_storyId_stories_id_fk",
-          "tableFrom": "reading_sessions",
-          "tableTo": "stories",
-          "columnsFrom": ["storyId"],
-          "columnsTo": ["id"],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.srs_cards": {
-      "name": "srs_cards",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "childId": {
-          "name": "childId",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "cardType": {
-          "name": "cardType",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "front": {
-          "name": "front",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "back": {
-          "name": "back",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "audioUrl": {
-          "name": "audioUrl",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "state": {
-          "name": "state",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "difficulty": {
-          "name": "difficulty",
-          "type": "real",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "stability": {
-          "name": "stability",
-          "type": "real",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "due": {
-          "name": "due",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "lastReview": {
-          "name": "lastReview",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "reps": {
-          "name": "reps",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "lapses": {
-          "name": "lapses",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "relatedPhonicsUnitId": {
-          "name": "relatedPhonicsUnitId",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "srs_cards_child_id_due_idx": {
-          "name": "srs_cards_child_id_due_idx",
-          "columns": [
-            {
-              "expression": "childId",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "due",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "srs_cards_childId_child_profiles_id_fk": {
-          "name": "srs_cards_childId_child_profiles_id_fk",
-          "tableFrom": "srs_cards",
-          "tableTo": "child_profiles",
-          "columnsFrom": ["childId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "srs_cards_relatedPhonicsUnitId_phonics_units_id_fk": {
-          "name": "srs_cards_relatedPhonicsUnitId_phonics_units_id_fk",
-          "tableFrom": "srs_cards",
-          "tableTo": "phonics_units",
-          "columnsFrom": ["relatedPhonicsUnitId"],
-          "columnsTo": ["id"],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.stories": {
-      "name": "stories",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "childId": {
-          "name": "childId",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
         },
         "title": {
           "name": "title",
-          "type": "varchar(200)",
+          "type": "varchar(160)",
           "primaryKey": false,
           "notNull": true
         },
-        "content": {
-          "name": "content",
-          "type": "jsonb",
+        "text": {
+          "name": "text",
+          "type": "text",
           "primaryKey": false,
           "notNull": true
         },
-        "theme": {
-          "name": "theme",
-          "type": "varchar(100)",
+        "targetWpm": {
+          "name": "targetWpm",
+          "type": "integer",
           "primaryKey": false,
           "notNull": true,
-          "default": "''"
+          "default": 10
         },
-        "targetPatterns": {
-          "name": "targetPatterns",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'"
-        },
-        "targetWords": {
-          "name": "targetWords",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'"
-        },
-        "decodabilityScore": {
-          "name": "decodabilityScore",
+        "targetAccuracy": {
+          "name": "targetAccuracy",
           "type": "real",
           "primaryKey": false,
           "notNull": true,
-          "default": 0
+          "default": 0.95
         },
-        "fleschKincaid": {
-          "name": "fleschKincaid",
-          "type": "real",
+        "topic": {
+          "name": "topic",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spellingListId": {
+          "name": "spellingListId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generatedBy": {
+          "name": "generatedBy",
+          "type": "varchar(16)",
           "primaryKey": false,
           "notNull": true,
-          "default": 0
-        },
-        "illustrationUrls": {
-          "name": "illustrationUrls",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'"
-        },
-        "aiGenerated": {
-          "name": "aiGenerated",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "favorited": {
-          "name": "favorited",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
+          "default": "'system'"
         },
         "createdAt": {
           "name": "createdAt",
@@ -1283,11 +1314,41 @@
         }
       },
       "indexes": {
-        "stories_child_id_idx": {
-          "name": "stories_child_id_idx",
+        "typing_lessons_slug_idx": {
+          "name": "typing_lessons_slug_idx",
           "columns": [
             {
-              "expression": "childId",
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "typing_lessons_stage_idx": {
+          "name": "typing_lessons_stage_idx",
+          "columns": [
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "typing_lessons_spelling_list_id_idx": {
+          "name": "typing_lessons_spelling_list_id_idx",
+          "columns": [
+            {
+              "expression": "spellingListId",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -1299,14 +1360,199 @@
           "with": {}
         }
       },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.typing_spelling_lists": {
+      "name": "typing_spelling_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "learnerId": {
+          "name": "learnerId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekOf": {
+          "name": "weekOf",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "words": {
+          "name": "words",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'type'"
+        },
+        "sourceImageUrl": {
+          "name": "sourceImageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "typing_spelling_lists_learner_id_week_of_idx": {
+          "name": "typing_spelling_lists_learner_id_week_of_idx",
+          "columns": [
+            {
+              "expression": "learnerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weekOf",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {
-        "stories_childId_child_profiles_id_fk": {
-          "name": "stories_childId_child_profiles_id_fk",
-          "tableFrom": "stories",
-          "tableTo": "child_profiles",
-          "columnsFrom": ["childId"],
+        "typing_spelling_lists_learnerId_typing_learners_id_fk": {
+          "name": "typing_spelling_lists_learnerId_typing_learners_id_fk",
+          "tableFrom": "typing_spelling_lists",
+          "tableTo": "typing_learners",
+          "columnsFrom": ["learnerId"],
           "columnsTo": ["id"],
-          "onDelete": "set null",
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "typing_spelling_lists_createdBy_users_id_fk": {
+          "name": "typing_spelling_lists_createdBy_users_id_fk",
+          "tableFrom": "typing_spelling_lists",
+          "tableTo": "users",
+          "columnsFrom": ["createdBy"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.typing_spelling_progress": {
+      "name": "typing_spelling_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "spellingListId": {
+          "name": "spellingListId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "word": {
+          "name": "word",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consecutiveCorrect": {
+          "name": "consecutiveCorrect",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "mastered": {
+          "name": "mastered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "masteredAt": {
+          "name": "masteredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "typing_spelling_progress_list_word_idx": {
+          "name": "typing_spelling_progress_list_word_idx",
+          "columns": [
+            {
+              "expression": "spellingListId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "word",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "typing_spelling_progress_spellingListId_typing_spelling_lists_id_fk": {
+          "name": "typing_spelling_progress_spellingListId_typing_spelling_lists_id_fk",
+          "tableFrom": "typing_spelling_progress",
+          "tableTo": "typing_spelling_lists",
+          "columnsFrom": ["spellingListId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
           "onUpdate": "no action"
         }
       },
@@ -1569,7 +1815,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'claude-sonnet-4-20250514'"
+          "default": "'claude-haiku-4-5'"
         },
         "temperature": {
           "name": "temperature",


### PR DESCRIPTION
## Summary

The meta snapshots for migrations 0011 (reading→typing cutover) and 0012 (typing_groups slug) were copies of 0010 — still describing the dropped reading-app tables (`stories`, `srs_cards`, `phonics_units`, …) and none of the `typing_*` tables. Every `drizzle-kit generate` since then diffed the schema against that stale state and hung on an interactive conflict prompt, which would have corrupted the next real schema change.

**The fix**: regenerated snapshot content from the current schema (cross-checked against the live post-migration database, which matches exactly) and grafted it into the existing chain:
- `0012_snapshot.json` — the exact current schema (22 tables)
- `0011_snapshot.json` — the same minus `typing_groups.slug` + its unique constraint (its true pre-0012 state)

Chain `id`/`prevId` values and `_journal.json` are untouched, so applied-migration tracking is unaffected. No SQL or runtime changes.

## Verification

- `drizzle-kit generate` → "No schema changes, nothing to migrate" (no prompt)
- `drizzle-kit check` → passes
- End-to-end proof: added a dummy column to the schema, `generate` produced exactly one clean `ALTER TABLE` with no prompts; reverted
- `pnpm db:migrate` applies cleanly; integration tests 79 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)