### PR TITLE
docs(server): correct the custom-SQL migration recipe that caused snapshot drift

### DIFF
--- a/packages/blog/server/CLAUDE.md
+++ b/packages/blog/server/CLAUDE.md
@@ -65,23 +65,34 @@ Both chat and artifacts use Anthropic beta APIs. Chat uses `beta.messages.stream
 
 PostgreSQL with Drizzle ORM.
 
-- **Schema**: `database/schema.ts`
+- **Schema**: `database/schema/` — barrel `index.ts`, feature files `blog.ts`, `typing.ts`, `workflow.ts`
 - **Access**: `useDrizzle()` from `utils/drizzle.ts` (creates connection per call)
-- **Tables**: `tables.chats` (with `containerId` for container reuse), `tables.messages`, `tables.users`, `tables.documents`, `tables.documentChunks`
+- **Tables**: `tables.chats` (with `containerId` for container reuse), `tables.messages`, `tables.users`, `tables.documents`, `tables.documentChunks`, plus the `typing_*` and `workflow_*` sets
 - **Migrations**: `pnpm db:generate` → `pnpm db:migrate`
 
 UUID primary keys generated via `crypto.randomUUID()`. All tables have `createdAt` timestamp.
 
 ### Custom SQL Migrations
 
-Drizzle can't express `tsvector` columns, triggers, or GIN indexes. For these:
+Never hand-edit anything under `migrations/meta/` (journal or snapshots). Hand-copied
+snapshots caused real drift once: migrations 0011/0012 changed tables but shipped
+copies of the 0010 snapshot, so every later `drizzle-kit generate` diffed against a
+fictional schema and hung on rename prompts (repaired in PR #275). Pick the path that
+matches the change:
 
-1. Create SQL file manually in `database/migrations/` (e.g. `0002_fix_name.sql`)
-2. Add entry to `meta/_journal.json` with next `idx`
-3. Copy previous snapshot as new `meta/NNNN_snapshot.json` (update `id`/`prevId` UUIDs)
-4. Keep Drizzle schema using `text().$type<string>()` workaround — don't change it
+- **Change expressible in the Drizzle schema** (tables, columns, constraints):
+  update `database/schema/*.ts`, run `pnpm db:generate` — it writes the SQL,
+  journal entry, and snapshot together. Then edit the generated SQL if the change
+  needs extras (backfills, `IF NOT EXISTS` guards); the snapshot stays correct.
+- **Change Drizzle can't express** (`tsvector` columns, triggers, GIN indexes,
+  data-only seeds): run `npx drizzle-kit generate --custom --name <name>` — it
+  scaffolds an empty SQL file with the journal entry and snapshot handled — then
+  write the SQL in the generated file. Keep the Drizzle schema on its
+  `text().$type<string>()`-style workaround; don't change it.
 
-The `document_chunks.searchVector` column is `text()` in Drizzle but `tsvector` in PostgreSQL (via custom migration). A trigger auto-populates it from `content` + `contextualContent`.
+The `document_chunks.searchVector` column is `text()` in Drizzle but `tsvector` in
+PostgreSQL (via custom migration). A trigger auto-populates it from `content` +
+`contextualContent`.
 
 ## RAG (Retrieval-Augmented Generation)
 


### PR DESCRIPTION
## Summary

Follow-up to #275. The server CLAUDE.md documented the custom-migration procedure as *'copy previous snapshot as new meta/NNNN_snapshot.json'* — which is exactly how the reading→typing cutover produced the snapshot drift #275 repaired (structural changes shipped with copies of the old snapshot, so every later `drizzle-kit generate` diffed against fiction).

Rewritten guidance:
- **Schema-expressible changes**: edit `database/schema/*.ts`, run `pnpm db:generate`, then edit the generated SQL if backfills/guards are needed — meta stays correct automatically.
- **Non-expressible changes** (tsvector, triggers, GIN indexes, seeds): `npx drizzle-kit generate --custom --name <name>` scaffolds an empty SQL file with the journal entry and snapshot handled.
- **Never hand-edit `migrations/meta/`.**

Verified `--custom` end-to-end against the repaired snapshots (correct chain ids, snapshot equality, journal entry) before recommending it. Also fixed the stale schema path (`database/schema.ts` → the `database/schema/` directory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)