### PR TITLE
chore(deps): batch 6 — @google/genai v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.1078.0",
-    "@google/genai": "^1.52.0",
+    "@google/genai": "^2.10.0",
     "youtube-transcript": "^1.3.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^3.1078.0
         version: 3.1078.0
       '@google/genai':
-        specifier: ^1.52.0
-        version: 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+        specifier: ^2.10.0
+        version: 2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
       youtube-transcript:
         specifier: ^1.3.1
         version: 1.3.1
@@ -1678,8 +1678,8 @@ packages:
     resolution: {integrity: sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==}
     engines: {node: '>=14'}
 
-  '@google/genai@1.52.0':
-    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+  '@google/genai@2.10.0':
+    resolution: {integrity: sha512-e4cFxj3tiuMtsgOT4G9c1hXyGJhg7/Buj7VVeBacRY3fRtkRZZ59Q3nuVp2xbq8BGQXLXCDB253qMhklMOeUDg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -11514,7 +11514,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
+  '@google/genai@2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.9.0
       p-retry: 4.6.2


### PR DESCRIPTION
## Summary

Sixth batch of the dependency upgrade plan: **@google/genai 1.52 → 2.10**. The v2 client rework left the surface this repo uses untouched — `new GoogleGenAI({apiKey})`, `ai.models.generateContent`, `Modality`, and `config.imageConfig.aspectRatio` compile and run unchanged across all three image-gen scripts (`generate-blog-image`, `generate-card-portraits`, `generate-demo-images`).

## Verification

- **Real generation run**: `scripts/generate-blog-image.ts` produced a correct 16:9 image via `gemini-2.5-flash-image` on v2
- Ad-hoc `tsc --noEmit` over the three scripts (they're outside every typecheck gate) — zero errors
- Script unit tests (8) pass; blog suite 615 passed; lint/typecheck clean
- genai is dev-time-scripts-only — no server runtime surface, so no dev-server/E2E round needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)