### PR TITLE
feat(slots): commit the slot-setup hook

### DIFF
--- a/slot-setup.sh
+++ b/slot-setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Run by slots.sh in a freshly created slot (cwd = the slot).
+set -euo pipefail
+pnpm install --prefer-offline


### PR DESCRIPTION
`ttr slot new` now runs the slot's own committed `slot-setup.sh` (towles-tool-rs#186) instead of a hub-root sidecar — this commits the hook (pnpm install) so the hub root holds nothing but `blog.git` and the slots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)