### PR TITLE
feat(tasks): rename worktree slots to tt tasks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,13 +12,5 @@
     "deny": [],
     "additionalDirectories": ["/home/ctowles/code/f"]
   },
-  "hooks": {
-    "WorktreeCreate": [
-      { "hooks": [{ "type": "command", "command": "tt slot hook-create" }] }
-    ],
-    "WorktreeRemove": [
-      { "hooks": [{ "type": "command", "command": "tt slot hook-remove" }] }
-    ]
-  },
   "enabledPlugins": {}
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,5 +12,13 @@
     "deny": [],
     "additionalDirectories": ["/home/ctowles/code/f"]
   },
+  "hooks": {
+    "WorktreeCreate": [
+      { "hooks": [{ "type": "command", "command": "tt slot hook-create" }] }
+    ],
+    "WorktreeRemove": [
+      { "hooks": [{ "type": "command", "command": "tt slot hook-remove" }] }
+    ]
+  },
   "enabledPlugins": {}
 }

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
-# Rendered into .env by `tt slot new` / `tt slot env` — ${tt:...} tokens are
-# per-slot substitutions (port pools, slot identity). Copying by hand instead?
+# Rendered into .env by `tt task new` / `tt task env` — ${tt:...} tokens are
+# per-task substitutions (port pools, task identity). Copying by hand instead?
 # Replace each token with a concrete value.
 
-# Slot identity (worktree-slot convention; harmless when unslotted)
-SLOT_NAME=${tt:slot-name}
+# Task identity (worktree-task convention; harmless in the main checkout)
+TASK_NAME=${tt:task-name}
 PR_BASE=${tt:base}
 
 # Docker Compose isolation (required for worktree support)
@@ -11,6 +11,15 @@ UI_PORT=${tt:port 3000-3019}
 DB_PORT=${tt:port 5432-5451}
 # MCP dev server port (package.json mcp:dev / kill-port read this)
 MCP_PORT=${tt:port 8081-8099}
+
+# Setup step `tt task new` runs in a fresh task (spawned directly, no shell).
+# Replaces the old slot-setup.sh.
+TT_TASK_SETUP=pnpm install --prefer-offline
+
+# Teardown step `tt task rm`/`clean` runs in the task right before removal.
+# The postgres container is named after TASK_NAME, so bring the stack (and its
+# volume) down before the worktree — and the rendered .env naming it — is gone.
+TT_TASK_TEARDOWN=docker compose down --volumes
 
 # PostgreSQL Connection
 # Local development (Docker Compose): Run `pnpm docker:up` from project root

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,8 @@
-# Rendered into .env by `ttr slot new` / `ttr slot env` — ${tt:...} tokens are
+# Rendered into .env by `tt slot new` / `tt slot env` — ${tt:...} tokens are
 # per-slot substitutions (port pools, slot identity). Copying by hand instead?
 # Replace each token with a concrete value.
 
 # Slot identity (worktree-slot convention; harmless when unslotted)
-SLOT=${tt:slot}
 SLOT_NAME=${tt:slot-name}
 PR_BASE=${tt:base}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,33 +40,6 @@ pnpm gcp:staging:deploy # Build container + deploy to GCP staging
 pnpm etl:aviation      # Download aviation datasets → Parquet → GCS (loads .env)
 ```
 
-## Worktree slots — you are probably working in one
-
-This repo is checked out as **slots**: `~/code/p/blog-repos/` holds a bare
-hub (`blog.git`) plus worktrees named `blog-slot-N`, one per parallel line of
-work (a `.tt-slot` marker sits at each slot's root). Manage slots with
-`ttr slot` — never raw `git worktree` or new clones:
-
-```bash
-ttr slot new -b feat/thing   # next free slot on a new branch (runs pnpm install)
-ttr slot ls                  # fleet: branch, dirty count, claimed ports
-ttr slot env <name>          # (re)render .env — idempotent, keeps claims + secrets
-ttr slot rm <name>           # guarded removal + docker compose down -v
-```
-
-Rules when working in a slot:
-
-- **`.env` is rendered, per slot** — `.env.example` is the template:
-  `${tt:port A-B}` pool claims give each slot its own `UI_PORT`, `DB_PORT`,
-  and `MCP_PORT`; `SLOT_NAME` names the slot's postgres container so
-  `pnpm docker:up` in two slots never collides. Never hardcode a port.
-- Secrets are inherited from a sibling slot's `.env` at creation and survive
-  re-renders; don't copy `.env` files between slots by hand.
-- **Detached HEAD means parked** — create a branch before committing;
-  commits reachable from no branch or remote block `ttr slot rm` by design.
-- **Never touch sibling slot directories** — other agents work there
-  concurrently.
-
 ## CLI Scripts
 
 Scripts in `packages/blog/scripts/` use **citty** for CLI structure (args, help, subcommands) and **consola** for formatted output (icons, colors, boxes). When adding new scripts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     # pgvector image includes the vector extension for RAG embeddings
     image: pgvector/pgvector:pg17
 
-    container_name: '${SLOT_NAME:-blog}-postgres_${DB_PORT}'
+    container_name: '${TASK_NAME:-blog}-postgres_${DB_PORT}'
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/slot-setup.sh
+++ b/slot-setup.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-# Run by slots.sh in a freshly created slot (cwd = the slot).
-set -euo pipefail
-pnpm install --prefer-offline


### PR DESCRIPTION
## Summary

`tt slot` became `tt task`, so this follows the rename repo-side and moves the
per-worktree setup/teardown steps out of a committed shell script and Claude
Code hooks into the `.env` template.

- **`.env.example`** — `SLOT_NAME` → `TASK_NAME`, `${tt:slot-name}` →
  `${tt:task-name}`, header names `tt task new` / `tt task env`.
- **`TT_TASK_SETUP`** replaces `slot-setup.sh` (`pnpm install --prefer-offline`).
- **`TT_TASK_TEARDOWN=docker compose down --volumes`** — the postgres container
  is named after `TASK_NAME`, so the stack and its volume have to come down
  while the rendered `.env` still exists.
- **`docker-compose.yml`** — container name reads `TASK_NAME`.
- **`.claude/settings.json`** — drops the `WorktreeCreate`/`WorktreeRemove`
  hooks, now covered by the env-template setup/teardown steps.
- **`CLAUDE.md`** — drops the worktree-slots section; the convention is no
  longer repo-specific.

Also included: the previously unpushed `feat(slots)` commit that wired the
worktree hooks, which this change supersedes.

## Test plan

Config/docs only — no application code touched. Verified by the rename being
complete: no `SLOT_NAME` or `${tt:slot-*}` tokens remain outside unrelated
Vue-slot references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)