### PR TITLE
fix(deploy): retry boot migration so a Cloud SQL cold start can't fail the revision

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -176,8 +176,11 @@ jobs:
           # gcloud run services update returns when the revision is created,
           # not when it serves traffic; first request also pays cold start +
           # the boot DB migration. Retry instead of a single shot.
-          echo "Smoke testing ${URL} (retry up to ~4 min)..."
-          for i in $(seq 1 24); do
+          # Window must outlast the container's boot-migration retry budget
+          # (MIGRATE_MAX_ATTEMPTS * MIGRATE_RETRY_DELAY, default ~3 min in
+          # infra/container/entrypoint.sh) plus image pull and cold start.
+          echo "Smoke testing ${URL} (retry up to ~6 min)..."
+          for i in $(seq 1 36); do
             STATUS=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "$URL" || echo 000)
             echo "  [attempt $i] HTTP ${STATUS}"
             if [ "$STATUS" -eq 200 ]; then

--- a/infra/container/entrypoint.sh
+++ b/infra/container/entrypoint.sh
@@ -1,8 +1,36 @@
 #!/bin/sh
 set -e
 
+# Cloud SQL can report RUNNABLE while still refusing connections — the Cloud
+# Run connector then fails the dial with "timed out after 10s". Staging hits
+# this on most deploys because the cost kill-switch stops the instance, so
+# every deploy pays a cold start.
+#
+# Without a retry, `set -e` aborts the container right here: the server never
+# binds $PORT, Cloud Run reports "STARTUP TCP probe failed ... instance was
+# not started", and the revision serves 500s until the smoke test gives up.
+# Retrying keeps a transient DB cold start from killing an otherwise healthy
+# revision. A genuinely broken migration still fails, just after the window.
 echo "Running database migrations..."
-node /app/.output/database/migrate.mjs
+MIGRATE_MAX_ATTEMPTS="${MIGRATE_MAX_ATTEMPTS:-18}"
+MIGRATE_RETRY_DELAY="${MIGRATE_RETRY_DELAY:-10}"
+
+attempt=1
+while :; do
+  if node /app/.output/database/migrate.mjs; then
+    echo "Migrations applied (attempt ${attempt})."
+    break
+  fi
+
+  if [ "$attempt" -ge "$MIGRATE_MAX_ATTEMPTS" ]; then
+    echo "Migrations failed after ${attempt} attempts; aborting startup." >&2
+    exit 1
+  fi
+
+  echo "  migration attempt ${attempt}/${MIGRATE_MAX_ATTEMPTS} failed — retrying in ${MIGRATE_RETRY_DELAY}s..."
+  attempt=$((attempt + 1))
+  sleep "$MIGRATE_RETRY_DELAY"
+done
 
 echo "Starting application..."
 # exec replaces this shell with node (node becomes PID 1)


### PR DESCRIPTION
Fixes the staging deploy failure on `main` (run [30161098452](https://github.com/ChrisTowles/blog/actions/runs/30161098452)), which failed its smoke test with **24 consecutive HTTP 500s** and consequently blocked `deploy-prod`.

## Root cause

Not application code. From the staging Cloud Run logs:

```
Cloud SQL connection failed ... connection to Cloud SQL instance at
34.122.96.81:3307 failed: timed out after 10s
Default STARTUP TCP probe failed 1 time consecutively for container
"blog-1" on port 3000. The instance was not started.
```

`infra/container/entrypoint.sh` ran migrations under `set -e` **before** starting the server:

```sh
set -e
node /app/.output/database/migrate.mjs   # <-- throws on a cold Cloud SQL
exec node /app/.output/server/index.mjs  # <-- never reached
```

Chain: Cloud SQL reports `RUNNABLE` but isn't yet accepting connections → connector dial times out at 10s → `set -e` aborts the container → server never binds `$PORT` → startup probe fails → revision serves 500s → smoke test fails → `deploy-prod` (which `needs: deploy-staging`) never runs.

Staging hits this on most deploys because the cost kill-switch stops the instance nightly, so every deploy pays a cold start. The workflow's existing "Wake up Cloud SQL" step waits for `RUNNABLE`, but that state does **not** imply connection readiness — which is the gap this closes.

This is timing-dependent, which is why the very next deploy passed staging: the DB was already warm.

## Fix

- Retry the boot migration: 18 attempts × 10s (~3 min), tunable via `MIGRATE_MAX_ATTEMPTS` / `MIGRATE_RETRY_DELAY`. A transient cold start no longer kills an otherwise healthy revision; a genuinely broken migration still exits 1 without starting the server.
- Widen the staging smoke-test window 4 min → 6 min so it outlasts the retry budget plus image pull and cold start.

## Verification

`sh -n` clean. Ran the script against a stubbed `migrate.mjs`:

| Scenario | Result |
|---|---|
| Fails twice, then succeeds | Retries, starts server, **exit 0** |
| Always fails | Stops at cap, does **not** start server, **exit 1** |

The second case matters — the retry must not paper over a real migration bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)