### PR TITLE
feat(home): give Towles Tool a wider cell in the experiment grid

### DIFF
--- a/packages/blog/app/pages/index.vue
+++ b/packages/blog/app/pages/index.vue
@@ -37,6 +37,8 @@ useSeoMeta({
       :data-testid="TEST_IDS.HOME.EXPERIMENTS"
     >
       <UPageGrid>
+        <!-- UPageGrid is 1/2/3 columns. `sm:col-span-2` gives the featured card
+             the full row at sm and two of the three columns from lg up. -->
         <UPageCard
           v-for="item in experiments"
           :key="item.to"
@@ -46,6 +48,8 @@ useSeoMeta({
           :to="item.to"
           :target="item.external ? '_blank' : undefined"
           :data-testid="item.testId"
+          :class="item.featured ? 'sm:col-span-2' : undefined"
+          :ui="item.featured ? { title: 'text-xl', description: 'text-base' } : undefined"
           spotlight
         />
       </UPageGrid>

--- a/packages/blog/app/utils/experiments.ts
+++ b/packages/blog/app/utils/experiments.ts
@@ -12,6 +12,8 @@ export type Experiment = {
    * actually serves.
    */
   external?: boolean;
+  /** Takes a wider cell in the home grid. Nothing else about the card changes. */
+  featured?: boolean;
 };
 
 /**
@@ -24,11 +26,12 @@ export const experiments: Experiment[] = [
   {
     title: 'Towles Tool',
     description:
-      'A CLI and Claude Code plugin for running several coding agents at once — git worktree tasks, a kanban board to see which agent needs input, and an autonomous loop that keeps going without me.',
+      "Where I test out interface ideas for working with coding agents. One git worktree per task, a kanban board instead of tabbing through terminals to find the one that's stuck, a loop that keeps going unattended. A CLI and a Claude Code plugin.",
     icon: 'i-lucide-terminal',
     to: 'https://github.com/ChrisTowles/towles-tool',
     testId: TEST_IDS.HOME.EXPERIMENT_TOWLES_TOOL,
     external: true,
+    featured: true,
   },
   {
     title: 'Agentic chat',


### PR DESCRIPTION
## What

Towles Tool read as just another card in the grid. Now it spans the full row at `sm` and two of the three columns from `lg` up, with a slightly larger title and body.

Same visual language as the rest of the grid — bigger, not louder. No CTA buttons, no install command, no image. The copy is reframed from a product description to what it actually is: where I test out interface ideas for working with coding agents.

## Implementation

`Experiment` gains a `featured` flag; the home grid maps it to `sm:col-span-2` plus a `:ui` override for title/description size. `UPageGrid` is 1/2/3 columns, so the featured card takes the whole row at `sm` and two of three from `lg` up, leaving three clean rows for eight cards.

`/about` is unaffected — Towles Tool is `external` and already excluded from "What's running here".

## Verification

- `pnpm lint`, `pnpm typecheck`, 542 unit tests, full Playwright suite
- Checked at 1280px and 800px

Note: hit the documented `_content_index` missing-table issue partway through and cleared `.nuxt`/`.data` per CLAUDE.md. That also removes the generated `tsconfig.app.json` the `build:ui-bundle` prestep needs, so `nuxt prepare` has to run before `pnpm dev` — worth knowing next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)