### PR TITLE
feat(home): label each experiment with its language and tech stack

### DIFF
--- a/packages/blog/app/pages/about.vue
+++ b/packages/blog/app/pages/about.vue
@@ -39,6 +39,12 @@ useSeoMeta({
           didn't. The failures are usually the more useful half.
         </p>
         <p>
+          Lately that's meant Rust. Towles Tool started as a TypeScript CLI and is being rewritten
+          as a Tauri desktop app, which turned out to be the good kind of hard — the borrow checker
+          rejects the sloppy version of the design before it reaches runtime, and I keep finding the
+          argument was right.
+        </p>
+        <p>
           This site is also where I test things. Everything listed below runs in production on this
           domain — the chat, the MCP server, the search, the typing app. If something here looks
           interesting,
@@ -68,7 +74,17 @@ useSeoMeta({
           :icon="item.icon"
           :to="item.to"
           spotlight
-        />
+        >
+          <template #footer>
+            <UBadge
+              :label="item.language"
+              color="neutral"
+              variant="subtle"
+              size="sm"
+              :data-testid="TEST_IDS.ABOUT.EXPERIMENT_LANGUAGE"
+            />
+          </template>
+        </UPageCard>
       </UPageGrid>
 
       <USeparator class="my-10" />

--- a/packages/blog/app/pages/about.vue
+++ b/packages/blog/app/pages/about.vue
@@ -39,10 +39,10 @@ useSeoMeta({
           didn't. The failures are usually the more useful half.
         </p>
         <p>
-          Lately that's meant Rust. Towles Tool started as a TypeScript CLI and is being rewritten
-          as a Tauri desktop app, which turned out to be the good kind of hard — the borrow checker
-          rejects the sloppy version of the design before it reaches runtime, and I keep finding the
-          argument was right.
+          Lately that's meant Rust. Towles Tool began as a Bun CLI driving tmux — one pane per
+          agent, which stopped scaling about the time I started hunting for the pane that was stuck.
+          It's now a Tauri desktop app in Rust. The borrow checker rejects the sloppy version of the
+          design before it reaches runtime, and I keep finding the argument was right.
         </p>
         <p>
           This site is also where I test things. Everything listed below runs in production on this
@@ -76,13 +76,17 @@ useSeoMeta({
           spotlight
         >
           <template #footer>
-            <UBadge
-              :label="item.language"
-              color="neutral"
-              variant="subtle"
-              size="sm"
-              :data-testid="TEST_IDS.ABOUT.EXPERIMENT_LANGUAGE"
-            />
+            <div class="flex flex-wrap gap-1.5" :data-testid="TEST_IDS.ABOUT.EXPERIMENT_LANGUAGE">
+              <UBadge :label="item.language" color="primary" variant="subtle" size="sm" />
+              <UBadge
+                v-for="tech in item.stack"
+                :key="tech"
+                :label="tech"
+                color="neutral"
+                variant="subtle"
+                size="sm"
+              />
+            </div>
           </template>
         </UPageCard>
       </UPageGrid>

--- a/packages/blog/app/pages/index.vue
+++ b/packages/blog/app/pages/index.vue
@@ -51,7 +51,17 @@ useSeoMeta({
           :class="item.featured ? 'sm:col-span-2' : undefined"
           :ui="item.featured ? { title: 'text-xl', description: 'text-base' } : undefined"
           spotlight
-        />
+        >
+          <template #footer>
+            <UBadge
+              :label="item.language"
+              color="neutral"
+              variant="subtle"
+              size="sm"
+              :data-testid="TEST_IDS.HOME.EXPERIMENT_LANGUAGE"
+            />
+          </template>
+        </UPageCard>
       </UPageGrid>
     </UPageSection>
 

--- a/packages/blog/app/pages/index.vue
+++ b/packages/blog/app/pages/index.vue
@@ -53,13 +53,17 @@ useSeoMeta({
           spotlight
         >
           <template #footer>
-            <UBadge
-              :label="item.language"
-              color="neutral"
-              variant="subtle"
-              size="sm"
-              :data-testid="TEST_IDS.HOME.EXPERIMENT_LANGUAGE"
-            />
+            <div class="flex flex-wrap gap-1.5" :data-testid="TEST_IDS.HOME.EXPERIMENT_LANGUAGE">
+              <UBadge :label="item.language" color="primary" variant="subtle" size="sm" />
+              <UBadge
+                v-for="tech in item.stack"
+                :key="tech"
+                :label="tech"
+                color="neutral"
+                variant="subtle"
+                size="sm"
+              />
+            </div>
           </template>
         </UPageCard>
       </UPageGrid>

--- a/packages/blog/app/utils/experiments.ts
+++ b/packages/blog/app/utils/experiments.ts
@@ -7,6 +7,13 @@ export type Experiment = {
   to: string;
   testId: string;
   /**
+   * What it's actually written in. Shown as a badge on each card so the grid
+   * says something about the work, not just what it does. Where a second
+   * language does the interesting part (the SQL behind search, the Rust
+   * behind the Tauri shell), name both rather than only the host language.
+   */
+  language: string;
+  /**
    * Set for projects that live off this domain. The "What's running here" list
    * on /about filters these out — it only claims things this Cloud Run service
    * actually serves.
@@ -30,6 +37,7 @@ export const experiments: Experiment[] = [
     icon: 'i-lucide-terminal',
     to: 'https://github.com/ChrisTowles/towles-tool',
     testId: TEST_IDS.HOME.EXPERIMENT_TOWLES_TOOL,
+    language: 'Rust',
     external: true,
     featured: true,
   },
@@ -40,6 +48,7 @@ export const experiments: Experiment[] = [
     icon: 'i-heroicons-chat-bubble-left-right',
     to: '/chat',
     testId: TEST_IDS.HOME.EXPERIMENT_CHAT,
+    language: 'TypeScript',
   },
   {
     title: 'Aviation MCP server',
@@ -48,6 +57,7 @@ export const experiments: Experiment[] = [
     icon: 'i-heroicons-paper-airplane',
     to: '/aviation',
     testId: TEST_IDS.HOME.EXPERIMENT_AVIATION,
+    language: 'TypeScript + SQL',
   },
   {
     title: 'Hybrid RAG search',
@@ -56,6 +66,7 @@ export const experiments: Experiment[] = [
     icon: 'i-heroicons-magnifying-glass',
     to: '/search',
     testId: TEST_IDS.HOME.EXPERIMENT_SEARCH,
+    language: 'TypeScript + SQL',
   },
   {
     title: 'Typing tutor',
@@ -64,6 +75,7 @@ export const experiments: Experiment[] = [
     icon: 'i-lucide-keyboard',
     to: '/typing',
     testId: TEST_IDS.HOME.EXPERIMENT_TYPING,
+    language: 'TypeScript',
   },
   {
     title: 'Workflows',
@@ -72,6 +84,7 @@ export const experiments: Experiment[] = [
     icon: 'i-lucide-workflow',
     to: '/workflows',
     testId: TEST_IDS.HOME.EXPERIMENT_WORKFLOWS,
+    language: 'TypeScript',
   },
   {
     title: 'Poker',
@@ -80,6 +93,7 @@ export const experiments: Experiment[] = [
     icon: 'i-lucide-spade',
     to: '/poker',
     testId: TEST_IDS.HOME.EXPERIMENT_POKER,
+    language: 'TypeScript',
   },
   {
     title: 'Apps',
@@ -88,6 +102,7 @@ export const experiments: Experiment[] = [
     icon: 'i-lucide-layout-grid',
     to: '/apps',
     testId: TEST_IDS.HOME.EXPERIMENT_APPS,
+    language: 'Mixed',
   },
 ];
 

--- a/packages/blog/app/utils/experiments.ts
+++ b/packages/blog/app/utils/experiments.ts
@@ -7,12 +7,16 @@ export type Experiment = {
   to: string;
   testId: string;
   /**
-   * What it's actually written in. Shown as a badge on each card so the grid
-   * says something about the work, not just what it does. Where a second
-   * language does the interesting part (the SQL behind search, the Rust
-   * behind the Tauri shell), name both rather than only the host language.
+   * The language it's actually written in. Rendered as the lead badge on each
+   * card so the grid says something about the work, not just what it does.
    */
   language: string;
+  /**
+   * The notable tech behind it, beyond the language. Keep these to things
+   * that are load-bearing and checkable in the repo — the point is to be
+   * specific ("DuckDB", "pgvector") rather than to list every dependency.
+   */
+  stack: string[];
   /**
    * Set for projects that live off this domain. The "What's running here" list
    * on /about filters these out — it only claims things this Cloud Run service
@@ -38,6 +42,7 @@ export const experiments: Experiment[] = [
     to: 'https://github.com/ChrisTowles/towles-tool',
     testId: TEST_IDS.HOME.EXPERIMENT_TOWLES_TOOL,
     language: 'Rust',
+    stack: ['Tauri', 'TypeScript'],
     external: true,
     featured: true,
   },
@@ -49,6 +54,7 @@ export const experiments: Experiment[] = [
     to: '/chat',
     testId: TEST_IDS.HOME.EXPERIMENT_CHAT,
     language: 'TypeScript',
+    stack: ['Nuxt', 'Anthropic SDK', 'SSE'],
   },
   {
     title: 'Aviation MCP server',
@@ -57,7 +63,8 @@ export const experiments: Experiment[] = [
     icon: 'i-heroicons-paper-airplane',
     to: '/aviation',
     testId: TEST_IDS.HOME.EXPERIMENT_AVIATION,
-    language: 'TypeScript + SQL',
+    language: 'TypeScript',
+    stack: ['MCP', 'DuckDB', 'Parquet'],
   },
   {
     title: 'Hybrid RAG search',
@@ -66,7 +73,8 @@ export const experiments: Experiment[] = [
     icon: 'i-heroicons-magnifying-glass',
     to: '/search',
     testId: TEST_IDS.HOME.EXPERIMENT_SEARCH,
-    language: 'TypeScript + SQL',
+    language: 'TypeScript',
+    stack: ['Postgres', 'pgvector', 'Bedrock'],
   },
   {
     title: 'Typing tutor',
@@ -76,6 +84,7 @@ export const experiments: Experiment[] = [
     to: '/typing',
     testId: TEST_IDS.HOME.EXPERIMENT_TYPING,
     language: 'TypeScript',
+    stack: ['Vue', 'PixiJS', 'Cloud TTS'],
   },
   {
     title: 'Workflows',
@@ -85,6 +94,7 @@ export const experiments: Experiment[] = [
     to: '/workflows',
     testId: TEST_IDS.HOME.EXPERIMENT_WORKFLOWS,
     language: 'TypeScript',
+    stack: ['Vue Flow', 'Postgres'],
   },
   {
     title: 'Poker',
@@ -94,6 +104,7 @@ export const experiments: Experiment[] = [
     to: '/poker',
     testId: TEST_IDS.HOME.EXPERIMENT_POKER,
     language: 'TypeScript',
+    stack: ['PixiJS', 'Anthropic SDK'],
   },
   {
     title: 'Apps',
@@ -103,6 +114,7 @@ export const experiments: Experiment[] = [
     to: '/apps',
     testId: TEST_IDS.HOME.EXPERIMENT_APPS,
     language: 'Mixed',
+    stack: [],
   },
 ];
 

--- a/packages/blog/shared/test-ids.ts
+++ b/packages/blog/shared/test-ids.ts
@@ -62,9 +62,11 @@ export const TEST_IDS = {
     EXPERIMENT_WORKFLOWS: 'home-experiment-workflows',
     EXPERIMENT_POKER: 'home-experiment-poker',
     EXPERIMENT_APPS: 'home-experiment-apps',
+    EXPERIMENT_LANGUAGE: 'home-experiment-language',
   },
   ABOUT: {
     PAGE: 'about-page',
+    EXPERIMENT_LANGUAGE: 'about-experiment-language',
   },
   SEARCH: {
     PAGE: 'search-page',


### PR DESCRIPTION
Each experiment card now carries a **language** badge (primary) plus its **tech stack** (neutral), on both the home grid and the `/about` subset — same `experiments.ts` source of truth feeds both. The grid said what each thing does but nothing about what it's built with, which is usually what a reader is scanning for.

| Experiment | Language | Stack |
|---|---|---|
| Towles Tool | **Rust** | Tauri, TypeScript |
| Agentic chat | **TypeScript** | Nuxt, Anthropic SDK, SSE |
| Aviation MCP server | **TypeScript** | MCP, DuckDB, Parquet |
| Hybrid RAG search | **TypeScript** | Postgres, pgvector, Bedrock |
| Typing tutor | **TypeScript** | Vue, PixiJS, Cloud TTS |
| Workflows | **TypeScript** | Vue Flow, Postgres |
| Poker | **TypeScript** | PixiJS, Anthropic SDK |
| Apps | **Mixed** | — |

**Values are checked, not guessed** — Vue Flow and DuckDB from `package.json`, PixiJS from the deps, Tauri and Rust from the `towles-tool` repo (`{"Rust": 2703560, "TypeScript": 1741782}` via the languages API).

## /about prose

Adds a paragraph on Rust as the current focus, framed around the Towles Tool rewrite. The lineage is corrected from my first draft: it began as a **Bun CLI driving tmux** (one pane per agent), not a plain TypeScript CLI — the separate `towles-tool-tmux` repo confirms the earlier incarnation.

Worth knowing: **`/about` shows no Rust badge.** `hostedExperiments` filters out `external` entries, and Towles Tool is the only Rust project and lives off this domain. So Rust appears on the home grid and in the prose, but not in "What's running here" — accurate, just maybe not expected.

As with the rest of that page: the copy is about you, so edit it.

## Verification

`pnpm lint` clean · `pnpm typecheck` clean · `pnpm test` **542 passed, 11 skipped**.

Browser-verified: 8 badge groups on home, 7 on `/about`, every stack value rendering.

One note for whoever runs this locally: mid-review the dev server started serving an empty home page. That was the known Nuxt Content `Database integrity check failed` cache bug, not this change — `rm -rf packages/blog/.data` + `nuxt prepare` cleared it. `/about` was unaffected because it doesn't query content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)