### PR TITLE
fix(dev): stop pre-commit typecheck from crashing the dev server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,6 @@ DB_PORT=${tt:port 5432-5451}
 MCP_PORT=${tt:port 8081-8099}
 
 # Setup step `tt task new` runs in a fresh task (spawned directly, no shell).
-# Replaces the old slot-setup.sh.
 TT_TASK_SETUP=pnpm install --prefer-offline
 
 # Teardown step `tt task rm`/`clean` runs in the task right before removal.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,12 @@ pnpm dev
 
 The `nuxt prepare` step is not optional. `pnpm dev` runs `ui-bundle:build` first, and that Vite build reads `.nuxt/tsconfig.app.json` — which the `rm -rf` just deleted. Skip it and the dev server dies with `Tsconfig not found`, which looks unrelated to the cache clear that caused it.
 
+**What actually causes it: running `nuxt typecheck` while a dev server is up.** Typecheck regenerates `.nuxt`; the dev server reloads mid-write and a native addon (better-sqlite3 / duckdb) aborts the process — `terminate called after throwing an instance of 'Napi::Error'`, core dumped. It comes back missing the content tables, and because `index.vue` is wrapped in `v-if="page"` the home page renders blank, so it looks like a content bug rather than a crash.
+
+Pre-commit used to run `pnpm typecheck` on every commit, which killed the dev server routinely. It now runs `pnpm typecheck:precommit` (`scripts/typecheck-precommit.ts`), which skips typecheck when something is listening on `UI_PORT`. CI typechecks every push and PR, so this stays enforced. Two approaches were tried and rejected, both documented in that script: detecting the server by process name (`pgrep -f "nuxt.mjs dev"` matches the hook's own shell), and giving typecheck its own `buildDir` (a fresh build dir makes nuxt-og-image emit an empty template union, so `defineOgImage('SaaS', ...)` fails as `never`).
+
+So: don't run `pnpm typecheck` by hand with `pnpm dev` running. Stop the server first, or let CI do it.
+
 **Never accept pre-existing test failures.** When E2E, integration, or unit tests fail — even if the failures appear unrelated to your current work — fix them immediately. Every test in the suite must pass. Broken tests are not "pre-existing conditions" to work around; they are bugs to fix as soon as discovered.
 
 ## Pre-commit Hooks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,8 @@ Pre-commit used to run `pnpm typecheck` on every commit, which killed the dev se
 
 So: don't run `pnpm typecheck` by hand with `pnpm dev` running. Stop the server first, or let CI do it.
 
+**Run `pnpm prepare` from the main checkout, not a task worktree.** `simple-git-hooks` writes to `.git/hooks`, but inside a worktree `.git` is a file, so it fails with `ENOTDIR`. Git resolves hooks from the common `.git/hooks` anyway, so installing once from the main checkout covers every worktree.
+
 **Never accept pre-existing test failures.** When E2E, integration, or unit tests fail — even if the failures appear unrelated to your current work — fix them immediately. Every test in the suite must pass. Broken tests are not "pre-existing conditions" to work around; they are bugs to fix as soon as discovered.
 
 ## Pre-commit Hooks

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "format": "oxfmt --write",
     "format:check": "oxfmt --check",
     "typecheck": "pnpm --filter @chris-towles/blog typecheck",
+    "typecheck:precommit": "pnpm tsx scripts/typecheck-precommit.ts",
     "test": "pnpm --filter @chris-towles/blog test",
     "test:integration": "pnpm --filter @chris-towles/blog test:integration",
     "test:e2e": "pnpm --filter @chris-towles/blog test:e2e",
@@ -80,7 +81,7 @@
     "zx": "^8.8.5"
   },
   "simple-git-hooks": {
-    "pre-commit": "pnpm lint-staged && pnpm format && pnpm typecheck"
+    "pre-commit": "pnpm lint-staged && pnpm format && pnpm typecheck:precommit"
   },
   "lint-staged": {
     "*.png": "pnpm tsx scripts/compress-images.ts",

--- a/scripts/typecheck-precommit.ts
+++ b/scripts/typecheck-precommit.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env -S pnpx tsx
+import { spawnSync } from 'node:child_process';
+import net from 'node:net';
+import { consola } from 'consola';
+import dotenv from 'dotenv';
+import { findUpSync } from 'find-up';
+
+/**
+ * Pre-commit wrapper around `pnpm typecheck`.
+ *
+ * `nuxt typecheck` regenerates the build dir. When a `nuxt dev` server is
+ * running against that same `.nuxt`, the dev server reloads mid-write and a
+ * native addon (better-sqlite3 / duckdb) throws a Napi::Error that aborts the
+ * process outright:
+ *
+ *     terminate called after throwing an instance of 'Napi::Error'
+ *     Aborted (core dumped)
+ *
+ * The dev server then usually restarts without its Nuxt Content tables
+ * ("no such table: _content_index"), which renders the home page blank because
+ * index.vue is wrapped in `v-if="page"` — so it surfaces as "the site is
+ * broken" rather than "typecheck killed my server".
+ *
+ * Since pre-commit runs on every commit, this killed the dev server routinely.
+ * Skip typecheck when a dev server is up; CI runs `pnpm typecheck` on every
+ * push and pull request, so types stay enforced either way.
+ *
+ * Detection is by port, not process name. `pgrep -f "nuxt.mjs dev"` was tried
+ * first and matched any shell whose command line merely contained that string
+ * — including the pre-commit hook itself — which would have silently skipped
+ * typecheck forever.
+ *
+ * Isolating typecheck into its own build dir was also tried and rejected: a
+ * fresh build dir makes nuxt-og-image generate an empty template union, so
+ * `defineOgImage('SaaS', ...)` fails with "not assignable to type 'never'" —
+ * false errors that would block every commit.
+ */
+
+const envPath = findUpSync('.env');
+if (envPath) dotenv.config({ path: envPath, quiet: true });
+
+const port = Number(process.env.UI_PORT) || 3000;
+
+/** Nuxt may bind IPv4 or IPv6, so check both before declaring the port free. */
+function portInUse(host: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = net.connect({ port, host });
+    const done = (result: boolean) => {
+      socket.destroy();
+      resolve(result);
+    };
+    socket.once('connect', () => done(true));
+    socket.once('error', () => done(false));
+    socket.setTimeout(500, () => done(false));
+  });
+}
+
+const devServerRunning = (await portInUse('127.0.0.1')) || (await portInUse('::1'));
+
+if (devServerRunning) {
+  consola.warn(`A dev server is listening on port ${port} — skipping typecheck for this commit.`);
+  consola.info('Running it now would abort that server and blank its content database.');
+  consola.info('CI typechecks every push and PR, so this is still enforced.');
+  process.exit(0);
+}
+
+const result = spawnSync('pnpm', ['typecheck'], { stdio: 'inherit' });
+process.exit(result.status ?? 1);


### PR DESCRIPTION
The recurring "Nuxt Content is broken / home page is blank" problem was never a content bug. This fixes the actual cause.

## What was happening

`nuxt typecheck` regenerates `.nuxt`. When a `nuxt dev` server is running against that same build dir, it reloads mid-write and a native addon (better-sqlite3 / duckdb) aborts the process:

```
terminate called after throwing an instance of 'Napi::Error'
Aborted (core dumped)
```

It restarts without its content tables (`no such table: _content_index`), and since `index.vue` is wrapped in `v-if="page"`, the home page renders **blank** — so it presents as a content-database problem rather than a crash.

**Pre-commit ran `pnpm typecheck` on every commit**, so this fired constantly.

Reproduced directly: with a healthy server serving 897KB, running `pnpm typecheck` dropped it to 0 bytes and dumped core — while `contents.sqlite` was **untouched** (same inode, size, mtime). The database was never the problem.

## The fix

Pre-commit now runs `typecheck:precommit` (`scripts/typecheck-precommit.ts`), which skips typecheck when something is listening on `UI_PORT`. CI runs `pnpm typecheck` on every push and PR, so types stay enforced.

Two alternatives were tried and rejected — both documented in the script so they don't get retried:

| Approach | Why rejected |
|---|---|
| Detect via `pgrep -f "nuxt.mjs dev"` | Matches any command line containing that string, **including the hook's own shell** — would have silently skipped typecheck forever. Caught during testing. |
| Give typecheck its own `buildDir` | A fresh build dir makes nuxt-og-image emit an empty template union, so `defineOgImage('SaaS', ...)` fails as `not assignable to type 'never'`. False errors on every commit. |

## Old primary/slot leftovers

`core.hooksPath` in `.git/config` pointed at `/home/ctowles/code/p/blog-repos/blog-primary/.git/hooks` — a hollow leftover with one file, no working tree, no history. That indirection is why the updated hook first appeared not to install. Unset it so hooks resolve from the repo's own common `.git/hooks`, reinstalled there, and removed the `blog-repos` tree.

Also dropped `.env.example`'s dangling reference to `slot-setup.sh`, and documented that `pnpm prepare` must run from the main checkout — inside a worktree `.git` is a file, so `simple-git-hooks` fails with `ENOTDIR`.

## Verification

Both paths tested, including through the real git hook:

- **Dev server up** → skips, server survives (897,301 bytes before *and* after a real `git commit`)
- **Port free** → runs typecheck to completion, exit 0

`pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)