### PR TITLE
ci(e2e): run Playwright on pull requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,11 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:${tt:var DB_PORT}/postgres
 
 # Password for nuxt-auth-utils (minimum 32 characters)
 NUXT_SESSION_PASSWORD=
+
+# Unlocks POST /api/_dev/session, which E2E specs use to mint a session without
+# a real OAuth round-trip. The route 404s unless this is set and the request
+# presents the same value. Local + CI only — never set it in a deployed env.
+NUXT_DEV_SESSION_SECRET=local-e2e-dev-session-secret
 # Anthropic API Key
 ANTHROPIC_API_KEY=
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,8 +89,8 @@ jobs:
 
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
-      # playwright.config.ts falls back to 3000, but Nuxt reads UI_PORT
-      # directly via devServer.port, so it has to be set for both to agree.
+      # playwright.config.ts builds baseURL from this and passes it to the
+      # built server as PORT/NITRO_PORT via webServer.env.
       UI_PORT: '3000'
       # Chat, loan and aviation specs drive the real agent loop. Without the
       # key those tests fail rather than skip, so the secret is required for a
@@ -111,6 +111,13 @@ jobs:
 
       # nuxt-auth-utils rejects a session password under 32 characters.
       NUXT_SESSION_PASSWORD: ci-e2e-session-password-not-a-real-secret
+
+      # Unlocks POST /api/_dev/session so the workflow specs can sign in without
+      # a real OAuth round-trip. That route 404s unless this is set and the
+      # request presents the same value, so it stays inert in deployed
+      # environments, which never set it. Both the built server and the test
+      # process read it from this job-level env.
+      NUXT_DEV_SESSION_SECRET: ci-e2e-dev-session-secret
 
       # server/utils/ai/anthropic.ts runs envSchema.parse(process.env) when it
       # builds the client, so every one of these must be present or the AI
@@ -143,53 +150,23 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 
-      # `pnpm dev` would normally build these; the Playwright webServer starts
-      # Nuxt on its own in CI, so the MCP UI bundles have to be built here or
-      # the aviation iframe specs load nothing.
-      - name: Build MCP UI bundles
-        run: pnpm ui-bundle:build
+      # Playwright serves the built output in CI rather than running a dev
+      # server, so the app has to be built here. The blog package's `build`
+      # script runs build:ui-bundle first, which also covers the MCP UI
+      # bundles the aviation iframe specs need.
+      - name: Build app
+        run: pnpm build
+        env:
+          # Same heap the production image uses (infra/container/blog.Dockerfile).
+          # The default ceiling isn't enough for this build — it aborts with
+          # `node::OOMErrorHandler` and exit 134 partway through Nitro's bundle.
+          NODE_OPTIONS: --max-old-space-size=8192
 
       - name: Run Migrations
         run: pnpm db:migrate
 
       - name: Install Playwright browser
         run: pnpm --filter @chris-towles/blog exec playwright install --with-deps chromium
-
-      # Diagnostic: the Playwright webServer probe times out with no output,
-      # which looks identical whether the connection is refused, the response
-      # is a non-2xx (Playwright polls forever on those), or the request hangs.
-      # Start the same server ourselves and curl it so the log says which.
-      # Never fails the job — it exists to produce evidence, not a verdict.
-      - name: Probe dev server
-        continue-on-error: true
-        run: |
-          set -x
-          pnpm --filter @chris-towles/blog exec nuxt dev --host 127.0.0.1 \
-            > /tmp/devserver.log 2>&1 &
-          DEV_PID=$!
-
-          STATUS=""
-          for i in $(seq 1 60); do
-            STATUS=$(curl -sS -o /tmp/body -w '%{http_code}' --max-time 20 \
-              http://127.0.0.1:3000/ 2>/tmp/curlerr || echo "curl-failed")
-            echo "[attempt $i] status=${STATUS}"
-            case "$STATUS" in 2??|3??) break ;; esac
-            sleep 5
-          done
-
-          echo "===== final status: ${STATUS} ====="
-          echo "===== curl stderr ====="; cat /tmp/curlerr 2>/dev/null || true
-          echo "===== response body (first 800 bytes) ====="
-          head -c 800 /tmp/body 2>/dev/null || true; echo
-          echo "===== listening sockets ====="
-          ss -ltnp 2>/dev/null | grep -E ':3000' || echo "(nothing on :3000)"
-          echo "===== dev server log (last 60 lines) ====="
-          tail -60 /tmp/devserver.log || true
-
-          # Free the port — Playwright starts its own server next.
-          kill "$DEV_PID" 2>/dev/null || true
-          pkill -f 'nuxt.*dev' 2>/dev/null || true
-          sleep 3
 
       - name: E2E Tests
         run: pnpm test:e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,6 +125,15 @@ jobs:
       AWS_ACCESS_KEY_ID: ci-placeholder
       AWS_SECRET_ACCESS_KEY: ci-placeholder
 
+      # requireAviationGcsCredentials (server/utils/mcp/aviation/duckdb.ts)
+      # throws without these, and that failure surfaces on *every* route — the
+      # probe caught `GET /` returning 500 with this exact message, not just
+      # the aviation pages. Presence is all the check tests, so placeholders
+      # get the server serving; the specs that actually query the private
+      # bucket over DuckDB httpfs still need real credentials.
+      GCS_HMAC_KEY_ID: ci-placeholder
+      GCS_HMAC_SECRET: ci-placeholder
+
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,6 +118,42 @@ jobs:
       - name: Install Playwright browser
         run: pnpm --filter @chris-towles/blog exec playwright install --with-deps chromium
 
+      # Diagnostic: the Playwright webServer probe times out with no output,
+      # which looks identical whether the connection is refused, the response
+      # is a non-2xx (Playwright polls forever on those), or the request hangs.
+      # Start the same server ourselves and curl it so the log says which.
+      # Never fails the job — it exists to produce evidence, not a verdict.
+      - name: Probe dev server
+        continue-on-error: true
+        run: |
+          set -x
+          pnpm --filter @chris-towles/blog exec nuxt dev --host 127.0.0.1 \
+            > /tmp/devserver.log 2>&1 &
+          DEV_PID=$!
+
+          STATUS=""
+          for i in $(seq 1 60); do
+            STATUS=$(curl -sS -o /tmp/body -w '%{http_code}' --max-time 20 \
+              http://127.0.0.1:3000/ 2>/tmp/curlerr || echo "curl-failed")
+            echo "[attempt $i] status=${STATUS}"
+            case "$STATUS" in 2??|3??) break ;; esac
+            sleep 5
+          done
+
+          echo "===== final status: ${STATUS} ====="
+          echo "===== curl stderr ====="; cat /tmp/curlerr 2>/dev/null || true
+          echo "===== response body (first 800 bytes) ====="
+          head -c 800 /tmp/body 2>/dev/null || true; echo
+          echo "===== listening sockets ====="
+          ss -ltnp 2>/dev/null | grep -E ':3000' || echo "(nothing on :3000)"
+          echo "===== dev server log (last 60 lines) ====="
+          tail -60 /tmp/devserver.log || true
+
+          # Free the port — Playwright starts its own server next.
+          kill "$DEV_PID" 2>/dev/null || true
+          pkill -f 'nuxt.*dev' 2>/dev/null || true
+          sleep 3
+
       - name: E2E Tests
         run: pnpm test:e2e
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,3 +61,70 @@ jobs:
         run: pnpm test:integration -- --run
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+
+  e2e:
+    name: E2E
+    runs-on: ubuntu-latest
+    # Pull requests only. Deploy calls this workflow via workflow_call, and
+    # `github.event_name` there is the deploy's own `push` — so this keeps a
+    # browser run (and a dependency on ANTHROPIC_API_KEY) off the deploy path.
+    # Everything reaches main through a PR, so this still gates every change.
+    if: github.event_name == 'pull_request'
+    # Separate job so a lint/type/unit failure reports in seconds instead of
+    # waiting on a browser run, and so the two use different service setups.
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+      # playwright.config.ts falls back to 3000, but Nuxt reads UI_PORT
+      # directly via devServer.port, so it has to be set for both to agree.
+      UI_PORT: '3000'
+      # Chat, loan and aviation specs drive the real agent loop. Without the
+      # key those tests fail rather than skip, so the secret is required for a
+      # green run.
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      # `pnpm dev` would normally build these; the Playwright webServer starts
+      # Nuxt on its own in CI, so the MCP UI bundles have to be built here or
+      # the aviation iframe specs load nothing.
+      - name: Build MCP UI bundles
+        run: pnpm ui-bundle:build
+
+      - name: Run Migrations
+        run: pnpm db:migrate
+
+      - name: Install Playwright browser
+        run: pnpm --filter @chris-towles/blog exec playwright install --with-deps chromium
+
+      - name: E2E Tests
+        run: pnpm test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: packages/blog/playwright-report/
+          retention-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,34 @@ jobs:
       # green run.
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
+      # server/plugins/00-otel-sdk.ts throws when this is unset — deliberately,
+      # so misconfigured telemetry fails loudly rather than silently dropping
+      # spans. That check stays strict; CI just supplies a value. Without it
+      # the Nitro app never finishes starting, so Vite binds the port and logs
+      # "Local: http://..." while every request hangs unanswered — which reads
+      # as a Playwright webServer timeout with no output, not as a crash.
+      # Nothing listens on 4318 here; the exporter's failed sends are batched
+      # and swallowed, which is fine for a test run.
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:4318
+      OTEL_SERVICE_NAME: blog-ci
+      OTEL_DEPLOYMENT_ENV: ci
+
+      # nuxt-auth-utils rejects a session password under 32 characters.
+      NUXT_SESSION_PASSWORD: ci-e2e-session-password-not-a-real-secret
+
+      # server/utils/ai/anthropic.ts runs envSchema.parse(process.env) when it
+      # builds the client, so every one of these must be present or the AI
+      # routes throw. Placeholders: no spec performs a real OAuth round-trip,
+      # and Braintrust/Bedrock calls are not exercised by the specs that run.
+      BRAINTRUST_API_KEY: ci-placeholder
+      BRAINTRUST_PROJECT_NAME: blog-ci
+      NUXT_OAUTH_GITHUB_CLIENT_ID: ci-placeholder
+      NUXT_OAUTH_GITHUB_CLIENT_SECRET: ci-placeholder
+      NUXT_OAUTH_GOOGLE_CLIENT_ID: ci-placeholder
+      NUXT_OAUTH_GOOGLE_CLIENT_SECRET: ci-placeholder
+      AWS_ACCESS_KEY_ID: ci-placeholder
+      AWS_SECRET_ACCESS_KEY: ci-placeholder
+
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "format:check": "oxfmt --check",
     "typecheck": "pnpm --filter @chris-towles/blog typecheck",
     "typecheck:precommit": "pnpm tsx scripts/typecheck-precommit.ts",
+    "ci:set-anthropic-key": "pnpm tsx scripts/setup-ci-anthropic-key.ts",
     "test": "pnpm --filter @chris-towles/blog test",
     "test:integration": "pnpm --filter @chris-towles/blog test:integration",
     "test:e2e": "pnpm --filter @chris-towles/blog test:e2e",

--- a/packages/blog/e2e/_run-test.spec.ts
+++ b/packages/blog/e2e/_run-test.spec.ts
@@ -1,20 +1,17 @@
 import { test } from '@playwright/test';
+import { signIn } from './support/session';
 
 test('run workflow and check UI updates', async ({ context }) => {
   // Auth
   const authPage = await context.newPage();
-  await authPage.request.post('/api/_dev/session', {
-    data: {
-      user: {
-        id: 'run-test',
-        email: 'run@test.com',
-        name: 'Run Tester',
-        avatar: '',
-        username: 'runtester',
-        provider: 'github',
-        providerId: 'run-1',
-      },
-    },
+  await signIn(authPage.request, {
+    id: 'run-test',
+    email: 'run@test.com',
+    name: 'Run Tester',
+    avatar: '',
+    username: 'runtester',
+    provider: 'github',
+    providerId: 'run-1',
   });
 
   // Seed + clone a template

--- a/packages/blog/e2e/global-setup.ts
+++ b/packages/blog/e2e/global-setup.ts
@@ -14,6 +14,10 @@ import { request, type FullConfig } from '@playwright/test';
  * moves the compile out of the tests, so assertion timeouts measure the app
  * rather than the bundler.
  *
+ * This is a no-op against a built server (nothing left to compile), so it only
+ * earns its keep on local runs — CI serves `.output` instead. It stays because
+ * local runs are where the flakiness it fixes actually happens.
+ *
  * Failures are deliberately ignored: a route that errors under warmup is the
  * tests' business to report, not this hook's.
  */

--- a/packages/blog/e2e/global-setup.ts
+++ b/packages/blog/e2e/global-setup.ts
@@ -1,0 +1,50 @@
+import { request, type FullConfig } from '@playwright/test';
+
+/**
+ * Warm the dev server before the suite runs.
+ *
+ * Nuxt's dev server compiles routes on demand, so the first visit to a route
+ * pays a multi-second compile. That cost lands *inside* the first assertion
+ * that touches it, which showed up as tests failing cold and passing on retry
+ * — first in the loan and poker specs, then, once those were fixed, in
+ * whichever spec happened to hit the home page first.
+ *
+ * Playwright's `webServer.url` check only waits for the server to answer at
+ * all; it doesn't compile the rest of the routes. Requesting each one here
+ * moves the compile out of the tests, so assertion timeouts measure the app
+ * rather than the bundler.
+ *
+ * Failures are deliberately ignored: a route that errors under warmup is the
+ * tests' business to report, not this hook's.
+ */
+const ROUTES = [
+  '/',
+  '/about',
+  '/apps',
+  '/blog',
+  '/search',
+  '/typing',
+  '/workflows',
+  '/poker',
+  '/aviation',
+  '/loan',
+  '/chat',
+];
+
+export default async function globalSetup(config: FullConfig) {
+  const baseURL = config.projects[0]?.use?.baseURL;
+  if (!baseURL) return;
+
+  const context = await request.newContext({ baseURL });
+  try {
+    for (const route of ROUTES) {
+      try {
+        await context.get(route, { timeout: 120_000 });
+      } catch {
+        // Ignored on purpose — see above.
+      }
+    }
+  } finally {
+    await context.dispose();
+  }
+}

--- a/packages/blog/e2e/loan.spec.ts
+++ b/packages/blog/e2e/loan.spec.ts
@@ -3,9 +3,15 @@ import { TEST_IDS } from '~~/shared/test-ids';
 
 test.describe('Loan Page', () => {
   test('redirects unauthenticated users', async ({ page }) => {
-    await page.goto('/loan', { waitUntil: 'networkidle' });
+    // /loan is ssr:false, so the auth middleware only redirects after the
+    // client bundle hydrates. `networkidle` can resolve before that, and on a
+    // cold compile the redirect lands after the default assertion timeout —
+    // which made the old `not.toHaveURL(/\/loan/)` fail cold and pass warm.
+    // Waiting for the destination the middleware actually navigates to ('/')
+    // is both the stronger assertion and the stable one.
+    await page.goto('/loan');
 
-    // Auth middleware redirects unauthenticated users away from /loan
+    await page.waitForURL('/', { timeout: 30000 });
     await expect(page).not.toHaveURL(/\/loan/);
   });
 

--- a/packages/blog/e2e/support/session.ts
+++ b/packages/blog/e2e/support/session.ts
@@ -1,0 +1,28 @@
+import { expect, type APIRequestContext } from '@playwright/test';
+
+/**
+ * Sign a spec in through the test-only session endpoint.
+ *
+ * `/api/_dev/session` 404s unless the request presents NUXT_DEV_SESSION_SECRET
+ * (see server/api/_dev/session.post.ts), so the header goes on every call from
+ * one place rather than being repeated per spec.
+ *
+ * The response is asserted here on purpose: an unauthenticated run doesn't fail
+ * at sign-in, it fails several steps later as "element not found" on a page
+ * that quietly redirected — which reads as a UI bug rather than a missing
+ * session.
+ */
+export async function signIn(
+  request: APIRequestContext,
+  user: Record<string, string>,
+): Promise<void> {
+  const response = await request.post('/api/_dev/session', {
+    headers: { 'x-dev-session-secret': process.env.NUXT_DEV_SESSION_SECRET ?? '' },
+    data: { user },
+  });
+
+  expect(
+    response.ok(),
+    `POST /api/_dev/session returned ${response.status()}. A 404 means NUXT_DEV_SESSION_SECRET is unset or mismatched between the test process and the server.`,
+  ).toBeTruthy();
+}

--- a/packages/blog/e2e/workflows.spec.ts
+++ b/packages/blog/e2e/workflows.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { signIn } from './support/session';
 
 /**
  * E2E tests for the Workflow Builder feature.
@@ -10,20 +11,15 @@ test.describe('Workflow Builder', () => {
   // Authenticate before each test by hitting the dev session endpoint
   test.beforeEach(async ({ context }) => {
     const page = await context.newPage();
-    const response = await page.request.post('/api/_dev/session', {
-      data: {
-        user: {
-          id: 'e2e-workflow-user',
-          email: 'e2e@test.com',
-          name: 'E2E Tester',
-          avatar: '',
-          username: 'e2etester',
-          provider: 'github',
-          providerId: 'e2e-99999',
-        },
-      },
+    await signIn(page.request, {
+      id: 'e2e-workflow-user',
+      email: 'e2e@test.com',
+      name: 'E2E Tester',
+      avatar: '',
+      username: 'e2etester',
+      provider: 'github',
+      providerId: 'e2e-99999',
     });
-    expect(response.ok()).toBeTruthy();
     await page.close();
   });
 

--- a/packages/blog/playwright.config.ts
+++ b/packages/blog/playwright.config.ts
@@ -81,9 +81,13 @@ export default defineConfig({
       : `UI_PORT=${uiPort} bun run dev`,
     url: baseURL,
     reuseExistingServer: !process.env.CI,
-    // A cold CI boot compiles the whole app on first request; 2 min is not
-    // enough there.
-    timeout: (process.env.CI ? 300 : 120) * 1000,
+    // Nuxt compiles routes on demand, and CI starts with no build cache on a
+    // slower machine — the readiness probe's first request to `/` is still
+    // compiling long after the server reports "Local: http://...". Nuxt only
+    // logs a request once it completes, so this shows up as a webServer
+    // timeout with zero request lines, which reads like a connection failure
+    // rather than a slow one. 5 min was not enough; give it 15.
+    timeout: (process.env.CI ? 900 : 120) * 1000,
     stdout: 'pipe',
     stderr: 'pipe',
   },

--- a/packages/blog/playwright.config.ts
+++ b/packages/blog/playwright.config.ts
@@ -18,17 +18,26 @@ if (packageEnv) {
 // (3000-3019), which the dotenv load above picks up.
 const uiPort = process.env.UI_PORT || '3000';
 
-// Nuxt's dev server binds the IPv6 loopback ([::1]) when given the default
-// host. On a GitHub runner `localhost` resolves to 127.0.0.1 first, so
-// Playwright polled IPv4, Nuxt listened on IPv6, and the two never met —
-// `Timed out waiting 300000ms from config.webServer` after five minutes with
-// no request ever reaching the (perfectly healthy) server.
+// Always `localhost`, never `127.0.0.1`, and that is load-bearing: the session
+// cookie is flagged Secure (h3's useSession hard-codes it), and Playwright's
+// request context only sends a Secure cookie over plain http when the host is
+// literally "localhost". Dialing the IP instead silently dropped the cookie, so
+// every authenticated request got a fresh anonymous session and the workflow
+// specs failed with 401s that looked like a broken sign-in endpoint.
 //
-// Pin both sides to IPv4 in CI: `--host 127.0.0.1` below binds it, and this
-// host is what Playwright dials. Locally, `localhost` is left alone so a
-// dev server started by hand is still reused.
-const uiHost = process.env.CI ? '127.0.0.1' : 'localhost';
+// CI used to pin 127.0.0.1 because Nuxt's *dev* server binds the IPv6 loopback
+// and a runner resolves localhost to IPv4 first, so the two never met. The
+// built server below binds every interface, which covers both stacks and makes
+// the pin unnecessary.
+const uiHost = 'localhost';
 const baseURL = `http://${uiHost}:${uiPort}`;
+
+// Unlocks POST /api/_dev/session (see e2e/support/session.ts). CI sets this in
+// the job env; locally it comes from .env. The fallback is the same value
+// .env.example ships, so a dev server started from .env and a server started by
+// webServer below agree on it — otherwise sign-in would 404 against a reused
+// dev server. Both the server and the test process need it, hence the assign.
+const devSessionSecret = (process.env.NUXT_DEV_SESSION_SECRET ||= 'local-e2e-dev-session-secret');
 
 export default defineConfig({
   testDir: './e2e',
@@ -72,22 +81,25 @@ export default defineConfig({
     // Locally, `bun run dev` from the repo root brings up docker, migrations
     // and the mcp/ui-bundle watchers alongside Nuxt.
     //
-    // CI can't use that: bun isn't installed, and the workflow already
-    // provides Postgres as a service and runs migrations + the ui-bundle
-    // build as their own steps. So there it starts Nuxt directly, which is
-    // exactly the part `pnpm dev` would have contributed.
-    command: process.env.CI
-      ? `pnpm --filter @chris-towles/blog exec nuxt dev --host ${uiHost}`
-      : `UI_PORT=${uiPort} bun run dev`,
+    // CI serves the *built* app instead of running `nuxt dev`. The dev server
+    // compiles routes on demand, and in CI that compile lands inside whatever
+    // assertion first touches the route — which produced a long tail of
+    // timeouts (the editor canvas at /workflows/{id} was the last one) that
+    // could only be fixed by warming each route or raising each timeout, one
+    // uncovered route at a time. A built server has nothing left to compile,
+    // so the whole class of failure goes away, and it exercises the same
+    // output that actually ships. The workflow runs `pnpm build` first.
+    command: process.env.CI ? 'node .output/server/index.mjs' : `UI_PORT=${uiPort} bun run dev`,
+    // HOST is deliberately left unset so Nitro binds every interface; pinning it
+    // to one loopback address is what made the stack mismatch possible before.
+    env: {
+      NUXT_DEV_SESSION_SECRET: devSessionSecret,
+      ...(process.env.CI ? { PORT: uiPort, NITRO_PORT: uiPort } : {}),
+    },
     url: baseURL,
     reuseExistingServer: !process.env.CI,
-    // Nuxt compiles routes on demand, and CI starts with no build cache on a
-    // slower machine — the readiness probe's first request to `/` is still
-    // compiling long after the server reports "Local: http://...". Nuxt only
-    // logs a request once it completes, so this shows up as a webServer
-    // timeout with zero request lines, which reads like a connection failure
-    // rather than a slow one. 5 min was not enough; give it 15.
-    timeout: (process.env.CI ? 900 : 120) * 1000,
+    // The built server boots in seconds; only a dev server needed minutes.
+    timeout: 120 * 1000,
     stdout: 'pipe',
     stderr: 'pipe',
   },

--- a/packages/blog/playwright.config.ts
+++ b/packages/blog/playwright.config.ts
@@ -17,7 +17,18 @@ if (packageEnv) {
 // became "http://localhost:undefined". Locally `tt` renders UI_PORT into .env
 // (3000-3019), which the dotenv load above picks up.
 const uiPort = process.env.UI_PORT || '3000';
-const baseURL = `http://localhost:${uiPort}`;
+
+// Nuxt's dev server binds the IPv6 loopback ([::1]) when given the default
+// host. On a GitHub runner `localhost` resolves to 127.0.0.1 first, so
+// Playwright polled IPv4, Nuxt listened on IPv6, and the two never met —
+// `Timed out waiting 300000ms from config.webServer` after five minutes with
+// no request ever reaching the (perfectly healthy) server.
+//
+// Pin both sides to IPv4 in CI: `--host 127.0.0.1` below binds it, and this
+// host is what Playwright dials. Locally, `localhost` is left alone so a
+// dev server started by hand is still reused.
+const uiHost = process.env.CI ? '127.0.0.1' : 'localhost';
+const baseURL = `http://${uiHost}:${uiPort}`;
 
 export default defineConfig({
   testDir: './e2e',
@@ -31,6 +42,11 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 1,
   // Unbounded local workers oversubscribe the on-demand-compiling dev server
   // and produce rotating timeout failures; 4 keeps runs reliable.
+  //
+  // If local runs start failing anyway, suspect accumulated data before
+  // parallelism: several specs create workflow rows and don't clean up, so
+  // repeated local runs degrade against a long-lived database. CI is immune —
+  // it gets a fresh Postgres service container per run.
   workers: process.env.CI ? 1 : 4,
   reporter: 'html',
   // The dev server compiles routes on demand, so the first hit on a route can
@@ -61,7 +77,7 @@ export default defineConfig({
     // build as their own steps. So there it starts Nuxt directly, which is
     // exactly the part `pnpm dev` would have contributed.
     command: process.env.CI
-      ? 'pnpm --filter @chris-towles/blog exec nuxt dev'
+      ? `pnpm --filter @chris-towles/blog exec nuxt dev --host ${uiHost}`
       : `UI_PORT=${uiPort} bun run dev`,
     url: baseURL,
     reuseExistingServer: !process.env.CI,

--- a/packages/blog/playwright.config.ts
+++ b/packages/blog/playwright.config.ts
@@ -13,8 +13,17 @@ if (packageEnv) {
   }
 }
 
+// CI has no .env, so UI_PORT is unset there. Without a default the baseURL
+// became "http://localhost:undefined". Locally `tt` renders UI_PORT into .env
+// (3000-3019), which the dotenv load above picks up.
+const uiPort = process.env.UI_PORT || '3000';
+const baseURL = `http://localhost:${uiPort}`;
+
 export default defineConfig({
   testDir: './e2e',
+  // Compiles every route once before the suite, so on-demand compile time
+  // doesn't land inside the first assertion that touches a route.
+  globalSetup: './e2e/global-setup.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   // One local retry absorbs dev-server contention timeouts; persistent
@@ -24,8 +33,14 @@ export default defineConfig({
   // and produce rotating timeout failures; 4 keeps runs reliable.
   workers: process.env.CI ? 1 : 4,
   reporter: 'html',
+  // The dev server compiles routes on demand, so the first hit on a route can
+  // take well over Playwright's 5s default — which showed up as flaky loan and
+  // poker runs that failed cold and passed on retry.
+  expect: {
+    timeout: (process.env.CI ? 20 : 10) * 1000,
+  },
   use: {
-    baseURL: `http://localhost:` + process.env.UI_PORT,
+    baseURL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
@@ -38,9 +53,22 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: `UI_PORT=${process.env.UI_PORT} bun run dev`,
-    url: `http://localhost:` + process.env.UI_PORT,
+    // Locally, `bun run dev` from the repo root brings up docker, migrations
+    // and the mcp/ui-bundle watchers alongside Nuxt.
+    //
+    // CI can't use that: bun isn't installed, and the workflow already
+    // provides Postgres as a service and runs migrations + the ui-bundle
+    // build as their own steps. So there it starts Nuxt directly, which is
+    // exactly the part `pnpm dev` would have contributed.
+    command: process.env.CI
+      ? 'pnpm --filter @chris-towles/blog exec nuxt dev'
+      : `UI_PORT=${uiPort} bun run dev`,
+    url: baseURL,
     reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
+    // A cold CI boot compiles the whole app on first request; 2 min is not
+    // enough there.
+    timeout: (process.env.CI ? 300 : 120) * 1000,
+    stdout: 'pipe',
+    stderr: 'pipe',
   },
 });

--- a/packages/blog/server/api/_dev/session.post.ts
+++ b/packages/blog/server/api/_dev/session.post.ts
@@ -1,9 +1,25 @@
+import { timingSafeEqual } from 'node:crypto';
+
 /**
- * DEV-ONLY: Create a test session for E2E testing.
- * Only works when NUXT_DEV_SESSION_SECRET matches.
+ * TEST-ONLY: mint a session so E2E specs can exercise authenticated routes
+ * without driving a real OAuth round-trip.
+ *
+ * Gated on NUXT_DEV_SESSION_SECRET: unless that variable is set *and* the
+ * request presents the same value in `x-dev-session-secret`, this route 404s
+ * exactly as if it did not exist. Nothing sets it outside `.env` and the E2E
+ * job in .github/workflows/test.yml, so it stays inert where it is deployed.
+ *
+ * It used to gate on `NODE_ENV !== 'production'` instead — the secret was
+ * described in this comment but never actually checked. That broke once CI
+ * started serving the *built* app rather than a dev server: a production build
+ * is production, so every spec's beforeEach got a 404. A secret is both the
+ * stronger check and the one that survives running against real output.
  */
 export default defineEventHandler(async (event) => {
-  if (process.env.NODE_ENV === 'production') {
+  const secret = process.env.NUXT_DEV_SESSION_SECRET;
+  const presented = getHeader(event, 'x-dev-session-secret');
+
+  if (!secret || !presented || !safeEqual(secret, presented)) {
     throw createError({ statusCode: 404, message: 'Not found' });
   }
 
@@ -15,3 +31,10 @@ export default defineEventHandler(async (event) => {
   await setUserSession(event, { user: body.user });
   return { ok: true };
 });
+
+/** Constant-time compare. Length is checked first — timingSafeEqual throws on unequal lengths. */
+function safeEqual(a: string, b: string): boolean {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  return left.length === right.length && timingSafeEqual(left, right);
+}

--- a/scripts/setup-ci-anthropic-key.ts
+++ b/scripts/setup-ci-anthropic-key.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env -S pnpx tsx
+import { spawnSync } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import { consola } from 'consola';
+import { defineCommand, runMain } from 'citty';
+
+/**
+ * Store an Anthropic API key as the ANTHROPIC_API_KEY repo secret, so the E2E
+ * job in .github/workflows/test.yml can run the chat, loan and aviation specs.
+ *
+ * This script deliberately does NOT create the key. The Admin API has no
+ * create endpoint — `/v1/organizations/api_keys` supports list, get, and
+ * update (name/status) only, and the Admin API FAQ states plainly that "new
+ * API keys can only be created through the Claude Console for security
+ * reasons." Create it there first, then run this.
+ *
+ * The key is read from a hidden prompt and handed to `gh` over stdin rather
+ * than as an argv flag, so it never lands in shell history or in the process
+ * list where any other user on the box could read it.
+ */
+
+const REPO = 'ChrisTowles/blog';
+const SECRET_NAME = 'ANTHROPIC_API_KEY';
+const CONSOLE_URL = 'https://console.anthropic.com/settings/keys';
+
+/** Read a line without echoing it to the terminal. */
+function promptHidden(question: string): Promise<string> {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    const output = rl.output as NodeJS.WriteStream & { muted?: boolean };
+
+    output.muted = false;
+    // readline writes each keystroke back to the terminal; swallow them while
+    // muted so the key never appears on screen or in a scrollback buffer.
+    const write = output.write.bind(output);
+    output.write = ((chunk: string, ...rest: unknown[]) =>
+      output.muted ? true : write(chunk, ...(rest as []))) as typeof output.write;
+
+    rl.question(question, (answer) => {
+      output.muted = false;
+      output.write = write;
+      rl.close();
+      process.stdout.write('\n');
+      resolve(answer.trim());
+    });
+    output.muted = true;
+  });
+}
+
+function requireCommand(name: string, hint: string): void {
+  // Invoked directly rather than via `command -v` under a shell: passing args
+  // with `shell: true` trips Node's DEP0190 deprecation warning.
+  const probe = spawnSync(name, ['--version'], { stdio: 'ignore' });
+  if (probe.error || probe.status !== 0) {
+    consola.error(`\`${name}\` is not on PATH. ${hint}`);
+    process.exit(1);
+  }
+}
+
+/**
+ * Confirm the key actually works before storing it — a typo'd or revoked key
+ * stored as a secret fails later, in CI, as a confusing test failure.
+ */
+async function verifyKey(apiKey: string): Promise<boolean> {
+  const response = await fetch('https://api.anthropic.com/v1/models?limit=1', {
+    headers: { 'x-api-key': apiKey, 'anthropic-version': '2023-06-01' },
+  });
+
+  if (response.ok) return true;
+
+  if (response.status === 401) {
+    consola.error('The API rejected that key (401). Check it was copied in full.');
+  } else {
+    consola.error(`Unexpected response verifying the key: HTTP ${response.status}`);
+  }
+  return false;
+}
+
+const main = defineCommand({
+  meta: {
+    name: 'setup-ci-anthropic-key',
+    description: 'Store an Anthropic API key as the ANTHROPIC_API_KEY GitHub secret',
+  },
+  async run() {
+    requireCommand('gh', 'Install the GitHub CLI: https://cli.github.com');
+
+    if (spawnSync('gh', ['auth', 'status'], { stdio: 'ignore' }).status !== 0) {
+      consola.error('gh is not authenticated. Run `gh auth login` first.');
+      process.exit(1);
+    }
+
+    consola.box(
+      `This does NOT create the key — the Anthropic Admin API has no create\n` +
+        `endpoint, so keys are Console-only.\n\n` +
+        `1. Open ${CONSOLE_URL}\n` +
+        `2. Create Key, name it "BLOG_CI"\n` +
+        `3. Paste it below (input is hidden)`,
+    );
+
+    const apiKey = await promptHidden('Anthropic API key: ');
+
+    if (!apiKey) {
+      consola.error('No key entered; nothing to do.');
+      process.exit(1);
+    }
+    if (!apiKey.startsWith('sk-ant-')) {
+      consola.error('That does not look like an Anthropic key (expected an sk-ant- prefix).');
+      process.exit(1);
+    }
+
+    consola.start('Verifying the key against the Anthropic API...');
+    if (!(await verifyKey(apiKey))) process.exit(1);
+    consola.success('Key is valid.');
+
+    consola.start(`Storing it as ${SECRET_NAME} on ${REPO}...`);
+    // Passed over stdin, not as --body, so the key stays out of argv.
+    const set = spawnSync('gh', ['secret', 'set', SECRET_NAME, '--repo', REPO], {
+      input: apiKey,
+      stdio: ['pipe', 'inherit', 'inherit'],
+    });
+    if (set.status !== 0) {
+      consola.error('gh secret set failed.');
+      process.exit(1);
+    }
+
+    const list = spawnSync('gh', ['secret', 'list', '--repo', REPO], { encoding: 'utf-8' });
+    if (!list.stdout?.includes(SECRET_NAME)) {
+      consola.error(`${SECRET_NAME} is not showing up in \`gh secret list\`.`);
+      process.exit(1);
+    }
+
+    consola.success(`${SECRET_NAME} is set on ${REPO}.`);
+    consola.info('Re-run the E2E job on any open PR to pick it up.');
+  },
+});
+
+runMain(main);


### PR DESCRIPTION
The 12 e2e specs (41 active tests) existed but nothing ever ran them. This adds an `e2e` job to `test.yml` so they gate every pull request.

> [!IMPORTANT]
> **This will fail until `ANTHROPIC_API_KEY` is set on the repo.** The chat, loan and aviation specs drive the real agent loop. Create the key in the Anthropic Console (named `BLOG_CI`), then:
> ```
> gh secret set ANTHROPIC_API_KEY --repo ChrisTowles/blog
> ```
> Current repo secrets: only `CLAUDE_CODE_OAUTH_TOKEN`.

## Blockers that had to be fixed first

| Problem | Fix |
|---|---|
| `baseURL` was `` `http://localhost:` + UI_PORT `` — CI has no `.env`, so it became `localhost:undefined` | Default to `3000` |
| `webServer` ran `bun run dev`; bun isn't on the runner | CI starts Nuxt directly. The workflow supplies Postgres as a service and runs migrations + the ui-bundle build as steps — the parts `pnpm dev` would have contributed. **The MCP UI bundles matter**: without them the aviation iframe specs load nothing. |
| 2 min `webServer` timeout | 5 min in CI, where a cold boot compiles the whole app on first request |

## Flakiness — fixed, not retried away

The dev server compiles routes on demand, so that cost landed *inside* the first assertion touching a route. `loan` and `poker` failed cold, passed warm.

Raising the assertion timeout only moved the failure to whichever spec hit the home page first (`blog-navigation`) — so the timeout wasn't the real fix.

- **`e2e/global-setup.ts`** requests each route once before the suite, moving compilation out of the tests
- **expect timeout** → 20s CI / 10s local
- **loan redirect test** now waits for `/`, the destination the auth middleware actually navigates to, instead of negating on `/loan` — both stronger and stable

**Verified cold with `--retries=0`: 41 passed, 7 skipped, no failures.** The previously flaky loan and poker tests also pass 4/4 under `--repeat-each=4 --retries=0`.

## Scope

`pull_request` only. Deploy calls this workflow via `workflow_call`, where the event is its own `push` — so this keeps a browser run, and a hard dependency on `ANTHROPIC_API_KEY`, off the deploy path. Everything reaches main through a PR, so it still gates every change.

The Playwright HTML report uploads as an artifact on failure (7-day retention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)