### PR TITLE
chore(build): trim the production server bundle and quiet the build

### DIFF
--- a/infra/container/blog.Dockerfile
+++ b/infra/container/blog.Dockerfile
@@ -86,6 +86,13 @@ RUN --mount=type=cache,id=npm,target=/root/.npm npm install sharp pg
 # Copy built application (includes migrate.mjs and migrations/ from Nitro hook)
 COPY --from=builder /app/packages/blog/.output /app/.output
 
+# duckdb ships prebuilt bindings for both Linux libc flavours and Nitro traces
+# both into .output (~70 MB each). This image is node:24-slim — glibc — so the
+# musl copy can never be loaded. Dropping it halves the largest thing in the
+# bundle. Nitro's externals.traceOptions.ignore does not exclude it: the copy
+# happens per-package once anything in it is traced.
+RUN rm -rf /app/.output/server/node_modules/@duckdb/node-bindings-linux-x64-musl
+
 # Copy content directory for Nuxt Content (raw markdown files needed at runtime)
 COPY --from=builder /app/packages/blog/content /app/content
 

--- a/packages/blog/nuxt.config.ts
+++ b/packages/blog/nuxt.config.ts
@@ -24,7 +24,6 @@ export default defineNuxtConfig({
     'nuxt-og-image',
     '@nuxtjs/mdc',
     'nuxt-auth-utils',
-    '@nuxt/test-utils/module',
     'evlog/nuxt',
   ],
 
@@ -101,6 +100,10 @@ export default defineNuxtConfig({
     '/': { prerender: true },
     // Auth routes must NOT be pre-rendered — they are server-side OAuth handlers
     '/auth/**': { prerender: false },
+    // Admin is behind the `auth` middleware and every panel loads its data from
+    // authenticated endpoints, so a prerendered copy is a build-time cost that
+    // ships an empty shell. The crawler reached these from links on `/`.
+    '/admin/**': { prerender: false },
     // Chat pages don't need SSR (no SEO benefit, authenticated feature)
     // Note: There's a pre-existing Vite 8 beta + debug ESM issue affecting chat pages
     '/chat': { ssr: false },
@@ -158,10 +161,29 @@ export default defineNuxtConfig({
         // Ensure database output dir exists
         await mkdir(join(outputDir, 'database'), { recursive: true });
 
-        // Bundle migrate script with rollup
+        // Bundle migrate script with rollup.
+        //
+        // The resolution options are overridden rather than inherited: the
+        // tsconfig resolves to `moduleResolution: node10`, which TypeScript
+        // deprecated, so every build printed a TS5107 warning. Dropping the
+        // tsconfig entirely is not the fix — without its `paths` and generated
+        // Nuxt types the same pass emits ~550 TS2304/TS2307 errors. Keep the
+        // tsconfig, override just the resolution; output is byte-identical.
         const bundle = await rollup({
           input: join(rootDir, 'scripts/migrate.ts'),
-          plugins: [rollupResolve(), typescript({ tsconfig: join(rootDir, 'tsconfig.json') })],
+          plugins: [
+            rollupResolve(),
+            typescript({
+              tsconfig: join(rootDir, 'tsconfig.json'),
+              module: 'esnext',
+              moduleResolution: 'bundler',
+              target: 'es2022',
+              skipLibCheck: true,
+              // Types are checked by `nuxt typecheck`; this pass only emits.
+              declaration: false,
+              sourceMap: false,
+            }),
+          ],
           external: ['pg', /^node:/],
         });
         await bundle.write({
@@ -185,6 +207,17 @@ export default defineNuxtConfig({
   typescript: {
     // Note: Test files are checked by vitest, not nuxt typecheck
     // The nuxt typecheck will show false positives for test files
+  },
+
+  ogImage: {
+    // OG images render through Satori (`defineOgImage('SaaS', ...)`), never by
+    // screenshotting a real browser. Left on, the browser binding statically
+    // imports `playwright` into the server bundle, which pulled playwright and
+    // playwright-core — a test dependency — into the production image.
+    compatibility: {
+      runtime: { browser: false },
+      prerender: { browser: false },
+    },
   },
 
   icon: {


### PR DESCRIPTION
Four build-output problems, each verified against a clean `pnpm build`.

| Issue | Fix | Verified |
|---|---|---|
| `playwright` + `playwright-core` shipped in the production server bundle | Turn off nuxt-og-image's browser binding (OG images render via Satori) | `ls .output/server/node_modules \| grep playwright` → empty |
| `@nuxt/test-utils/module` registered as an app module | Removed | 542 unit tests still pass |
| `/admin/**` prerendered as an empty auth-gated shell | `prerender: false` route rule | no admin HTML in `.output/public` |
| TS5107 deprecation on every build (migrate-script rollup pass resolved `node10`) | Override `module`/`moduleResolution` while keeping the tsconfig | zero TypeScript diagnostics; emitted bundle byte-identical |

Dropping the tsconfig entirely was the obvious fix and is wrong: without its `paths` and the generated Nuxt types, the same pass emits ~550 `TS2304`/`TS2307` errors. Measured both ways before choosing.

Separately, the runtime image now deletes duckdb's musl bindings. duckdb ships prebuilt bindings for both libc flavours and Nitro traces both into `.output` at ~70 MB each; the runner is `node:24-slim` (glibc), so the musl copy can never load. `externals.traceOptions.ignore` does not exclude it — the copy is per-package once anything in it is traced.

## Verification

- `pnpm build` — exit 0, zero TS diagnostics
- `pnpm test` — 542 passed, 11 skipped
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- Built server booted and served `/` — 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)